### PR TITLE
fix: remove forcing non-null expression

### DIFF
--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -208,7 +208,7 @@ const AnnouncementsGrid = ({
   return (
     <>
       <ItemCardGrid>
-        {announcementsList?.results!.map((announcement, index) => (
+        {announcementsList?.results.map((announcement, index) => (
           <AnnouncementCard
             key={index}
             announcement={announcement}


### PR DESCRIPTION
Fixes an issue where forcing a non-null expression. From my understanding, this check tells Typescript we know the results will be present and not empty. That guarantee seems to be broken after updating dependencies. This PR aims to resolve the issue at hand and get things back to 🟢 .

```
Array.prototype.map called on null or undefined
```

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
