### PR TITLE
refactor: use backstage fetch api

### DIFF
--- a/plugins/announcements-backend/package.json
+++ b/plugins/announcements-backend/package.json
@@ -40,7 +40,6 @@
     "@backstage/plugin-search-common": "^1.2.6",
     "@procore-oss/backstage-plugin-announcements-common": "^0.0.7",
     "@types/express": "^4.17.6",
-    "cross-fetch": "^3.1.5",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^2.0.0",

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import { Logger } from 'winston';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { Announcement, AnnouncementsClient } from './api';
@@ -13,6 +13,7 @@ export type IndexableAnnouncementDocument = IndexableDocument & {
 type AnnouncementCollatorOptions = {
   logger: Logger;
   discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
 };
 
 export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
@@ -29,6 +30,7 @@ export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
     this.logger = options.logger;
     this.announcementsClient = new AnnouncementsClient({
       discoveryApi: options.discoveryApi,
+      fetchApi: options.fetchApi,
     });
   }
 

--- a/plugins/announcements-backend/src/search/api.ts
+++ b/plugins/announcements-backend/src/search/api.ts
@@ -1,5 +1,4 @@
-import crossFetch from 'cross-fetch';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 
 export type Announcement = {
@@ -12,21 +11,23 @@ export type Announcement = {
 };
 
 export type AnnouncementsList = {
-    count: number;
-    results: Announcement[];
+  count: number;
+  results: Announcement[];
 };
 
 export class AnnouncementsClient {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
 
-  constructor(opts: { discoveryApi: DiscoveryApi }) {
+  constructor(opts: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
     this.discoveryApi = opts.discoveryApi;
+    this.fetchApi = opts.fetchApi;
   }
 
   private async fetch<T = any>(input: string): Promise<T> {
     const baseApiUrl = await this.discoveryApi.getBaseUrl('announcements');
 
-    return crossFetch(`${baseApiUrl}${input}`).then(async response => {
+    return this.fetchApi.fetch(`${baseApiUrl}${input}`).then(async response => {
       if (!response.ok) {
         throw await ResponseError.fromResponse(response);
       }

--- a/plugins/announcements/package.json
+++ b/plugins/announcements/package.json
@@ -61,7 +61,6 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/luxon": "^3.3.2",
     "@types/node": "^16.11.26",
-    "cross-fetch": "^3.1.5",
     "msw": "^1.0.0"
   },
   "files": [

--- a/plugins/announcements/src/setupTests.ts
+++ b/plugins/announcements/src/setupTests.ts
@@ -1,2 +1,1 @@
 import '@testing-library/jest-dom';
-import 'cross-fetch/polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,7 +5465,6 @@ __metadata:
     "@types/supertest": ^2.0.8
     "@types/uuid": ^8.3.4
     better-sqlite3: ^8.0.0
-    cross-fetch: ^3.1.5
     express: ^4.17.1
     express-promise-router: ^4.1.0
     knex: ^2.0.0
@@ -5516,7 +5515,6 @@ __metadata:
     "@types/luxon": ^3.3.2
     "@types/node": ^16.11.26
     "@uiw/react-md-editor": ^3.19.5
-    cross-fetch: ^3.1.5
     luxon: ^3.4.3
     msw: ^1.0.0
     react-use: ^17.2.4


### PR DESCRIPTION
Summary:

We should use the provided APIs from Backstage

Details:

The backend is currently using `crossFetch`. Backstage provides a fetch API that wraps this with additional backstage-centric features. 

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
