### PR TITLE
fix: broken link to license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-`backstage-plugin-announcements` is [MIT licensed](LICENSE) and accepts contributions via
+`backstage-plugin-announcements` is [MIT licensed](LICENSE.md) and accepts contributions via
 GitHub pull requests. This document outlines some of the conventions on
 development workflow, commit message formatting, contact points, and other
 resources to make it easier to get your contribution accepted.


### PR DESCRIPTION
The link to the license in the contributing guide is incorrect

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
