### PR TITLE
test: AnnouncementDatabase

### DIFF
--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -2,6 +2,7 @@ import { TestDatabases } from '@backstage/backend-test-utils';
 import { AnnouncementsDatabase } from './AnnouncementsDatabase';
 import { Knex } from 'knex';
 import { initializePersistenceContext } from './persistenceContext';
+import { DateTime } from 'luxon';
 
 function createDatabaseManager(client: Knex, skipMigrations: boolean = false) {
   return {
@@ -30,6 +31,122 @@ describe('AnnouncementsDatabase', () => {
 
   it('should return an empty array when there are no announcements', async () => {
     const announcements = await store.announcements({});
+    expect(announcements).toEqual({
+      count: 0,
+      results: [],
+    });
+  });
+
+  it('should return an announcement by id', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+    });
+
+    const announcement = await store.announcementByID('id');
+
+    expect(announcement).toEqual({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      category: undefined,
+      sticky: null,
+      type: null,
+      created_at: '2023-10-13 15:28:08.539 +00:00',
+    });
+  });
+
+  it('should insert a new announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+    });
+
+    const announcements = await store.announcements({});
+
+    expect(announcements).toEqual({
+      count: 1,
+      results: [
+        {
+          id: 'id',
+          publisher: 'publisher',
+          title: 'title',
+          excerpt: 'excerpt',
+          body: 'body',
+          category: undefined,
+          sticky: null,
+          type: null,
+          created_at: '2023-10-13 15:28:08.539 +00:00',
+        },
+      ],
+    });
+  });
+
+  it('should update an existing announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+    });
+
+    await store.updateAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title2',
+      excerpt: 'excerpt2',
+      body: 'body2',
+      created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+    });
+
+    const announcements = await store.announcements({});
+
+    expect(announcements).toEqual({
+      count: 1,
+      results: [
+        {
+          id: 'id',
+          publisher: 'publisher',
+          title: 'title2',
+          excerpt: 'excerpt2',
+          body: 'body2',
+          category: undefined,
+          sticky: null,
+          type: null,
+          created_at: '2023-10-13 15:28:08.539 +00:00',
+        },
+      ],
+    });
+  });
+
+  it('should delete an existing announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+    });
+
+    expect((await store.announcements({})).count).toBe(1);
+
+    await store.deleteAnnouncementByID('id');
+
+    const announcements = await store.announcements({});
+
     expect(announcements).toEqual({
       count: 0,
       results: [],

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -152,4 +152,176 @@ describe('AnnouncementsDatabase', () => {
       results: [],
     });
   });
+
+  it('handles not finding an announcement', async () => {
+    expect(await store.announcementByID('id')).toBeUndefined();
+  });
+
+  describe('filters', () => {
+    it('categories', async () => {
+      database = createDatabaseManager(testDbClient);
+      const categoryStore = (await initializePersistenceContext(database))
+        .categoriesStore;
+
+      await categoryStore.insert({
+        slug: 'category',
+        title: 'Category',
+      });
+
+      await categoryStore.insert({
+        slug: 'different',
+        title: 'A different category',
+      });
+
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        category: 'category',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        category: 'category',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id3',
+        publisher: 'publisher3',
+        title: 'title3',
+        excerpt: 'excerpt3',
+        body: 'body3',
+        category: 'different',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      const announcements = await store.announcements({
+        category: 'category',
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id',
+            publisher: 'publisher',
+            title: 'title',
+            excerpt: 'excerpt',
+            body: 'body',
+            category: {
+              slug: 'category',
+              title: 'Category',
+            },
+            sticky: null,
+            type: null,
+            created_at: '2023-10-13 15:28:08.539 +00:00',
+          },
+          {
+            id: 'id2',
+            publisher: 'publisher2',
+            title: 'title2',
+            excerpt: 'excerpt2',
+            body: 'body2',
+            category: {
+              slug: 'category',
+              title: 'Category',
+            },
+            sticky: null,
+            type: null,
+            created_at: '2023-10-13 15:28:08.539 +00:00',
+          },
+        ],
+      });
+    });
+
+    it('offset', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      const announcements = await store.announcements({
+        offset: 1,
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id2',
+            publisher: 'publisher2',
+            title: 'title2',
+            excerpt: 'excerpt2',
+            body: 'body2',
+            category: undefined,
+            sticky: null,
+            type: null,
+            created_at: '2023-10-13 15:28:08.539 +00:00',
+          },
+        ],
+      });
+    });
+
+    it('max', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-13T15:28:08.539'),
+      });
+
+      const announcements = await store.announcements({
+        max: 1,
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id',
+            publisher: 'publisher',
+            title: 'title',
+            excerpt: 'excerpt',
+            body: 'body',
+            category: undefined,
+            sticky: null,
+            type: null,
+            created_at: '2023-10-13 15:28:08.539 +00:00',
+          },
+        ],
+      });
+    });
+  });
 });

--- a/plugins/announcements/src/api.ts
+++ b/plugins/announcements/src/api.ts
@@ -5,9 +5,9 @@ import {
   DiscoveryApi,
   ErrorApi,
   IdentityApi,
+  FetchApi,
 } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
-import { FetchApi } from '@backstage/core-plugin-api';
 import {
   Announcement,
   AnnouncementsList,


### PR DESCRIPTION
Adds unit tests for AnnouncementDatabase. This brings the persistence package to 100% test coverage. 

<img width="627" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/90ffbe8f-d5a3-40e6-828b-2c62a5e25f10">

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green
