### PR TITLE
test: announcements backend routes

### DIFF
--- a/plugins/announcements-backend/src/service/utils.test.ts
+++ b/plugins/announcements-backend/src/service/utils.test.ts
@@ -14,4 +14,8 @@ describe('timestampToDateTime', () => {
     expect(timestampToDateTime(sql).toISO()).toBe('2021-08-20T10:11:12.000Z');
     expect(timestampToDateTime(iso).toISO()).toBe('2021-08-20T10:11:12.000Z');
   });
+
+  it('throws error', () => {
+    expect(() => timestampToDateTime('foo')).toThrow('Not valid');
+  });
 });


### PR DESCRIPTION
Add unit tests for existing routes.

**Announcements**

- /GET
- /POST 
- /PUT

**Categories**

- /GET
- /POST

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
