### PR TITLE
refactor: replace SingleHostDiscovery with HostDiscovery

### DIFF
--- a/plugins/announcements-backend/src/service/standaloneServer.ts
+++ b/plugins/announcements-backend/src/service/standaloneServer.ts
@@ -6,7 +6,7 @@ import {
   useHotMemoize,
   ServerTokenManager,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { buildAnnouncementsContext } from './announcementsContextBuilder';
 import { createRouter } from './router';
@@ -25,7 +25,7 @@ export async function startStandaloneServer(
     service: 'announcements-backend-backend',
   });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const tokenManager = ServerTokenManager.fromConfig(config, { logger });
   const permissions = ServerPermissionClient.fromConfig(config, {
     discovery,


### PR DESCRIPTION
SingleHostDiscovery is deprecated.

<img width="648" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/aeb94361-b7e5-40d0-8f79-d0e7fc8b88b2">

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
