### PR TITLE
fix: use fetch in AnnouncementCollatorFactory

### DIFF
--- a/.changeset/spicy-glasses-listen.md
+++ b/.changeset/spicy-glasses-listen.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Collator uses native fetch instead of backstage fetchApi

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
@@ -2,7 +2,7 @@ import { AnnouncementCollatorFactory } from './AnnouncementCollatorFactory';
 import { Readable } from 'stream';
 import { getVoidLogger } from '@backstage/backend-common';
 import { TestPipeline } from '@backstage/plugin-search-backend-node';
-import { MockFetchApi, setupRequestMockHandlers } from '@backstage/test-utils';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
 import { AnnouncementsList } from '@procore-oss/backstage-plugin-announcements-common';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
@@ -39,7 +39,6 @@ const mockAnnouncements: AnnouncementsList = {
 
 describe('AnnouncementCollatorFactory', () => {
   const logger = getVoidLogger();
-  const mockFetchApi = new MockFetchApi();
   const mockDiscoveryApi = {
     getBaseUrl: jest.fn().mockReturnValue('http://localhost:7007/api'),
   };
@@ -47,7 +46,6 @@ describe('AnnouncementCollatorFactory', () => {
   const factory = AnnouncementCollatorFactory.fromConfig({
     logger,
     discoveryApi: mockDiscoveryApi,
-    fetchApi: mockFetchApi,
   });
 
   it('has expected type', () => {

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import { Logger } from 'winston';
-import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi } from '@backstage/core-plugin-api';
 import {
   DocumentCollatorFactory,
   IndexableDocument,
@@ -16,7 +16,6 @@ type IndexableAnnouncementDocument = IndexableDocument & {
 type AnnouncementCollatorOptions = {
   logger: Logger;
   discoveryApi: DiscoveryApi;
-  fetchApi: FetchApi;
 };
 
 export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
@@ -33,7 +32,6 @@ export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
     this.logger = options.logger;
     this.announcementsClient = new AnnouncementsClient({
       discoveryApi: options.discoveryApi,
-      fetchApi: options.fetchApi,
     });
   }
 

--- a/plugins/announcements-backend/src/search/api.test.ts
+++ b/plugins/announcements-backend/src/search/api.test.ts
@@ -1,4 +1,4 @@
-import { MockFetchApi, setupRequestMockHandlers } from '@backstage/test-utils';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
 import { AnnouncementsClient } from './api';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
@@ -9,11 +9,10 @@ describe('AnnouncementsClient', () => {
   const discoveryApi = { getBaseUrl: async () => mockBaseUrl };
 
   setupRequestMockHandlers(server);
-  const fetchApi = new MockFetchApi();
 
   let client: AnnouncementsClient;
   beforeEach(() => {
-    client = new AnnouncementsClient({ discoveryApi, fetchApi });
+    client = new AnnouncementsClient({ discoveryApi });
     server.listen();
   });
 

--- a/plugins/announcements-backend/src/search/api.ts
+++ b/plugins/announcements-backend/src/search/api.ts
@@ -1,4 +1,4 @@
-import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import {
   Announcement,
@@ -7,17 +7,15 @@ import {
 
 export class AnnouncementsClient {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly fetchApi: FetchApi;
 
-  constructor(opts: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
+  constructor(opts: { discoveryApi: DiscoveryApi }) {
     this.discoveryApi = opts.discoveryApi;
-    this.fetchApi = opts.fetchApi;
   }
 
   private async fetch<T = any>(input: string): Promise<T> {
     const baseApiUrl = await this.discoveryApi.getBaseUrl('announcements');
 
-    return this.fetchApi.fetch(`${baseApiUrl}${input}`).then(async response => {
+    return fetch(`${baseApiUrl}${input}`).then(async response => {
       if (!response.ok) {
         throw await ResponseError.fromResponse(response);
       }


### PR DESCRIPTION
The `fetchApi` provided by Backstage is intended to be used in the front-end. This PR updates the collator to use native fetch instead.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
