### PR TITLE
feat: support node 18 and 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "16 || 18"
+    "node": "18 || 20"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",

--- a/plugins/announcements/package.json
+++ b/plugins/announcements/package.json
@@ -60,7 +60,7 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
     "@types/luxon": "^3.2.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.18.6",
     "cross-fetch": "^3.1.5",
     "msw": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,7 +5614,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^14.0.0
     "@types/luxon": ^3.2.0
-    "@types/node": ^16.11.26
+    "@types/node": ^18.18.6
     "@uiw/react-md-editor": ^3.19.5
     cross-fetch: ^3.1.5
     luxon: ^3.2.0
@@ -6716,7 +6716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.11.26, @types/node@npm:^16.9.2":
+"@types/node@npm:^16.9.2":
   version: 16.18.10
   resolution: "@types/node@npm:16.18.10"
   checksum: 1b138616923e9a1c6d3806edf75714b605d2ec689357cdc675bc73816c508ff11b3c68df054b02a496c76654d8ed53add2e90816af39423431c73aa6eec06f29
@@ -6727,6 +6727,13 @@ __metadata:
   version: 18.14.0
   resolution: "@types/node@npm:18.14.0"
   checksum: d83fcf5e4ed544755dd9028f5cbb6b9d46235043159111bb2ad62223729aee581c0144a9f6df8ba73d74011db9ed4ebd7af2fd5e0996714e3beb508a5da8ac5c
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.18.6":
+  version: 18.18.6
+  resolution: "@types/node@npm:18.18.6"
+  checksum: a847639b8455fd3dfa6dbc2917274c82c9db789f1d41aaf69f94ac6c9e54c3c1dd29be6e1e1ccd7c17e54db3d78d7011bc4e70544c6447ceca253dccc0a187e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The create-app command provided by Backstage creates new instances that do not support node16. This PR moves away from node 16 and supports 18 and 20.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
