### PR TITLE
fix: use correct api path on collector

### DIFF
--- a/.changeset/fifty-olives-run.md
+++ b/.changeset/fifty-olives-run.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Fixed the correct endpoint call by AnnouncementCollatorApi

--- a/plugins/announcements-backend/src/search/api.ts
+++ b/plugins/announcements-backend/src/search/api.ts
@@ -30,6 +30,6 @@ export class AnnouncementsClient {
   }
 
   async announcements(): Promise<Announcement[]> {
-    return await this.fetch<Announcement[]>('/');
+    return await this.fetch<Announcement[]>('/announcements');
   }
 }


### PR DESCRIPTION

On the scheduled collector task for the search feature, it tries to fetch announcements on `GET /api/announcements/` , which makes search entries empty.

To be taken into account when https://github.com/procore-oss/backstage-plugin-announcements/issues/23 is started 😄 

Observed logs on our Backstage instance:
```
12:57:48.461Z[22m [34mbackstage[39m [32minfo[39m ::ffff:127.0.0.1 - - [24/Oct/2023:12:57:48 +0000] "GET /api/announcements/ HTTP/1.1" 401 12 "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" [36mtype[39m=incomingRequest
[1] [2m2023-10-24T12:57:48.474Z[22m [34msearch[39m [31merror[39m Collating documents for announcements failed: ResponseError: Request failed with 401 Error [36mtype[39m=plugin [36mdocumentType[39m=announcements
[1] [2m2023-10-24T12:57:48.474Z[22m [34mbackstage[39m [31merror[39m Request failed with 401 Error [36mtype[39m=taskManager [36mtask[39m=search_index_announcements [36mresponse[39m=[object Response] [36mbody[39m=[object Object] [36mcause[39m=Error: Request failed with status 401 Unauthorized, Unauthorized [36mname[39m=ResponseError [36mstack[39m=ResponseError: Request failed with 401 Error
[1]     at Function.fromResponse (/home/user/workspace/backstage/node_modules/@backstage/errors/dist/index.cjs.js:238:12)
[1]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[1]     at <anonymous> (/home/user/workspace/backstage/node_modules/@procore-oss/backstage-plugin-announcements-backend/dist/index.cjs.js:145:15)
[1]     at AnnouncementsClient.announcements (/home/user/workspace/backstage/node_modules/@procore-oss/backstage-plugin-announcements-backend/dist/index.cjs.js:151:12)
[1]     at AnnouncementCollatorFactory.execute (/home/user/workspace/backstage/node_modules/@procore-oss/backstage-plugin-announcements-backend/dist/index.cjs.js:171:21)
[1]     at async next (node:internal/streams/from:85:11)
[1] [2m2023-10-24T12:57:48.475Z[22m [34mbackstage[39m [90mdebug[39m task: search_index_announcements will next occur around 2023-10-24T15:07:48.474+02:00 [36mtype[39m=taskManager [36mtask[39m=search_index_announcements
```