### PR TITLE
fix: AnnouncementCollatorApi iterable error

### DIFF
--- a/.changeset/sixty-forks-divide.md
+++ b/.changeset/sixty-forks-divide.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Fix AnnouncementCollatorApi iterable error

--- a/plugins/announcements-backend/src/search/api.ts
+++ b/plugins/announcements-backend/src/search/api.ts
@@ -11,6 +11,11 @@ export type Announcement = {
   created_at: string;
 };
 
+export type AnnouncementsList = {
+  count: number;
+  results: Announcement[];
+};
+
 export class AnnouncementsClient {
   private readonly discoveryApi: DiscoveryApi;
 
@@ -30,6 +35,7 @@ export class AnnouncementsClient {
   }
 
   async announcements(): Promise<Announcement[]> {
-    return await this.fetch<Announcement[]>('/announcements');
+    const result = await this.fetch<AnnouncementsList>('/announcements');
+    return result?.results;
   }
 }


### PR DESCRIPTION
This time I tested it on my instance. Collector successfully fetched announcements.

```txt
[1] 2023-10-27T09:22:37.744Z search info Collating documents for announcements via AnnouncementCollatorFactory type=plugin documentType=announcements
[1] 2023-10-27T09:22:37.745Z search info indexing announcements type=plugin
[1] 2023-10-27T09:22:37.767Z backstage info ::ffff:127.0.0.1 - - [27/Oct/2023:09:22:37 +0000] "GET /api/announcements/announcements HTTP/1.1" 200 205 "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" type=incomingRequest
[1] 2023-10-27T09:22:37.770Z search debug got 1 announcements type=plugin
[1] 2023-10-27T09:22:37.770Z search debug mapping announcement 8541a1dc-2725-4c79-a367-dc91bd43282b to indexable document type=plugin
[1] 2023-10-27T09:22:37.779Z search info Collating documents for announcements succeeded type=plugin documentType=announcements
[1] 2023-10-27T09:22:37.782Z backstage debug task: search_index_announcements will next occur around 2023-10-27T11:32:37.780+02:00 type=taskManager task=search_index_announcements
```
