### PR TITLE
test: unit test announcements-backend

### DIFF
--- a/.changeset/shaggy-fans-glow.md
+++ b/.changeset/shaggy-fans-glow.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Improves test coverage significantly for the backend plugin

--- a/plugins/announcements-backend/package.json
+++ b/plugins/announcements-backend/package.json
@@ -31,12 +31,14 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.19.8",
+    "@backstage/backend-test-utils": "^0.2.7",
     "@backstage/config": "^1.1.1",
     "@backstage/core-plugin-api": "^1.7.0",
     "@backstage/errors": "^1.2.3",
     "@backstage/plugin-auth-node": "^0.4.0",
     "@backstage/plugin-permission-common": "^0.7.9",
     "@backstage/plugin-permission-node": "^0.7.17",
+    "@backstage/plugin-search-backend-node": "^1.2.10",
     "@backstage/plugin-search-common": "^1.2.7",
     "@procore-oss/backstage-plugin-announcements-common": "^0.1.2",
     "@types/express": "^4.17.6",
@@ -53,6 +55,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.23.1",
+    "@backstage/test-utils": "^1.4.4",
     "@types/supertest": "^2.0.15",
     "@types/uuid": "^8.3.4",
     "better-sqlite3": "^8.7.0",

--- a/plugins/announcements-backend/package.json
+++ b/plugins/announcements-backend/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.19.8",
-    "@backstage/backend-test-utils": "^0.2.7",
     "@backstage/config": "^1.1.1",
     "@backstage/core-plugin-api": "^1.7.0",
     "@backstage/errors": "^1.2.3",
@@ -54,6 +53,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "^0.2.7",
     "@backstage/cli": "^0.23.1",
     "@backstage/test-utils": "^1.4.4",
     "@types/supertest": "^2.0.15",

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
@@ -1,0 +1,81 @@
+import { AnnouncementCollatorFactory } from './AnnouncementCollatorFactory';
+import { Readable } from 'stream';
+import { getVoidLogger } from '@backstage/backend-common';
+import { TestPipeline } from '@backstage/plugin-search-backend-node';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+const mockAnnouncements = {
+  count: 3,
+  results: [
+    {
+      id: '1',
+      title: 'title',
+      publisher: 'publisher1',
+      body: 'body',
+      excerpt: 'excerpt',
+      created_at: 'created_at',
+    },
+    {
+      id: '2',
+      title: 'title',
+      publisher: 'publisher2',
+      body: 'body',
+      excerpt: 'excerpt',
+      created_at: 'created_at',
+    },
+    {
+      id: '3',
+      title: 'title',
+      publisher: 'publisher3',
+      body: 'body',
+      excerpt: 'excerpt',
+      created_at: 'created_at',
+    },
+  ],
+};
+
+describe('AnnouncementCollatorFactory', () => {
+  const logger = getVoidLogger();
+  const mockDiscoveryApi = {
+    getBaseUrl: jest.fn().mockReturnValue('http://localhost:7007/api'),
+  };
+
+  const factory = AnnouncementCollatorFactory.fromConfig({
+    logger,
+    discoveryApi: mockDiscoveryApi,
+  });
+
+  it('has expected type', () => {
+    expect(factory.type).toBe('announcements');
+  });
+
+  describe('getCollator', () => {
+    const worker = setupServer();
+    setupRequestMockHandlers(worker);
+
+    let collator: Readable;
+    beforeEach(async () => {
+      collator = await factory.getCollator();
+      worker.use(
+        rest.get('http://localhost:7007/api/announcements', (_, res, ctx) =>
+          res(ctx.status(200), ctx.json(mockAnnouncements)),
+        ),
+      );
+    });
+
+    it('should return a Readable stream', async () => {
+      collator = await factory.getCollator();
+      expect(collator).toBeInstanceOf(Readable);
+    });
+
+    it('runs against announcements', async () => {
+      collator = await factory.getCollator();
+      const pipeline = TestPipeline.fromCollator(collator);
+      const { documents } = await pipeline.execute();
+      // expect(mockDiscoveryApi.getBaseUrl).toHaveBeenCalledWith('announcements');
+      expect(documents).toHaveLength(mockAnnouncements.results.length);
+    });
+  });
+});

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.test.ts
@@ -74,7 +74,7 @@ describe('AnnouncementCollatorFactory', () => {
       collator = await factory.getCollator();
       const pipeline = TestPipeline.fromCollator(collator);
       const { documents } = await pipeline.execute();
-      // expect(mockDiscoveryApi.getBaseUrl).toHaveBeenCalledWith('announcements');
+      expect(mockDiscoveryApi.getBaseUrl).toHaveBeenCalledWith('announcements');
       expect(documents).toHaveLength(mockAnnouncements.results.length);
     });
   });

--- a/plugins/announcements-backend/src/search/api.test.ts
+++ b/plugins/announcements-backend/src/search/api.test.ts
@@ -1,0 +1,68 @@
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import { AnnouncementsClient } from './api';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+describe('AnnouncementsClient', () => {
+  const server = setupServer();
+  const mockBaseUrl = 'http://localhost:7007/api/';
+  const discoveryApi = { getBaseUrl: async () => mockBaseUrl };
+
+  setupRequestMockHandlers(server);
+
+  let client: AnnouncementsClient;
+  beforeEach(() => {
+    client = new AnnouncementsClient({ discoveryApi });
+    server.listen();
+  });
+
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it('handles no announcements', async () => {
+    server.use(
+      rest.get(`${mockBaseUrl}/announcements`, (_, res, ctx) =>
+        res(ctx.status(200), ctx.json({ count: 0, results: [] })),
+      ),
+    );
+    expect(await client.announcements()).toEqual([]);
+  });
+
+  it('returns announcements', async () => {
+    const announcements = [
+      {
+        id: '1',
+        title: 'announcement1',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'publisher',
+        created_at: '2021-01-01T00:00:00Z',
+      },
+      {
+        id: '1',
+        title: 'announcement2',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'publisher2',
+        created_at: '2021-01-02T00:00:00Z',
+      },
+    ];
+    server.use(
+      rest.get(`${mockBaseUrl}/announcements`, (_, res, ctx) =>
+        res(ctx.status(200), ctx.json({ count: 2, results: announcements })),
+      ),
+    );
+    expect(await client.announcements()).toEqual(announcements);
+  });
+
+  it('throws on error', async () => {
+    server.use(
+      rest.get(`${mockBaseUrl}/announcements`, (_, res, ctx) =>
+        res(ctx.status(500)),
+      ),
+    );
+    await expect(client.announcements()).rejects.toThrow(
+      'Request failed with 500 Error',
+    );
+  });
+});

--- a/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
+++ b/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
@@ -1,0 +1,34 @@
+import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import { buildAnnouncementsContext } from './announcementsContextBuilder';
+import { getVoidLogger } from '@backstage/backend-common';
+import { initializePersistenceContext } from './persistence/persistenceContext';
+
+jest.mock('./persistence/persistenceContext', () => ({
+  initializePersistenceContext: jest.fn(),
+}));
+
+describe('buildAnnouncementsContext', () => {
+  it('returns context with logger, persistenceContext, and permissions properties', async () => {
+    const logger = getVoidLogger();
+    const database = {
+      getClient: jest.fn(),
+      url: 'url',
+    };
+    const permissions: PermissionEvaluator = {
+      authorize: jest.fn(),
+      authorizeConditional: jest.fn(),
+    };
+
+    const context = await buildAnnouncementsContext({
+      logger,
+      database,
+      permissions,
+    });
+
+    expect(context).toStrictEqual({
+      logger,
+      persistenceContext: await initializePersistenceContext(database),
+      permissions,
+    });
+  });
+});

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -1,0 +1,320 @@
+import { TestDatabases } from '@backstage/backend-test-utils';
+import {
+  AnnouncementsDatabase,
+  timestampToDateTime,
+} from './AnnouncementsDatabase';
+import { Knex } from 'knex';
+import { initializePersistenceContext } from './persistenceContext';
+import { DateTime } from 'luxon';
+
+function createDatabaseManager(client: Knex, skipMigrations: boolean = false) {
+  return {
+    getClient: async () => client,
+    migrations: {
+      skip: skipMigrations,
+    },
+  };
+}
+
+describe('AnnouncementsDatabase', () => {
+  const databases = TestDatabases.create();
+  let store: AnnouncementsDatabase;
+  let testDbClient: Knex<any, unknown[]>;
+  let database;
+
+  beforeAll(async () => {
+    testDbClient = await databases.init('SQLITE_3');
+    database = createDatabaseManager(testDbClient);
+    store = (await initializePersistenceContext(database)).announcementsStore;
+  });
+
+  afterEach(async () => {
+    await testDbClient('announcements').delete();
+  });
+
+  it('should return an empty array when there are no announcements', async () => {
+    const announcements = await store.announcements({});
+    expect(announcements).toEqual({
+      count: 0,
+      results: [],
+    });
+  });
+
+  it('should return an announcement by id', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+    });
+
+    const announcement = await store.announcementByID('id');
+
+    expect(announcement).toEqual({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      category: undefined,
+      created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+    });
+  });
+
+  it('should insert a new announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+    });
+
+    const announcements = await store.announcements({});
+
+    expect(announcements).toEqual({
+      count: 1,
+      results: [
+        {
+          id: 'id',
+          publisher: 'publisher',
+          title: 'title',
+          excerpt: 'excerpt',
+          body: 'body',
+          category: undefined,
+          created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+        },
+      ],
+    });
+  });
+
+  it('should update an existing announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+    });
+
+    await store.updateAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title2',
+      excerpt: 'excerpt2',
+      body: 'body2',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+    });
+
+    const announcements = await store.announcements({});
+
+    expect(announcements).toEqual({
+      count: 1,
+      results: [
+        {
+          id: 'id',
+          publisher: 'publisher',
+          title: 'title2',
+          excerpt: 'excerpt2',
+          body: 'body2',
+          category: undefined,
+          created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+        },
+      ],
+    });
+  });
+
+  it('should delete an existing announcement', async () => {
+    await store.insertAnnouncement({
+      id: 'id',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+    });
+
+    expect((await store.announcements({})).count).toBe(1);
+
+    await store.deleteAnnouncementByID('id');
+
+    const announcements = await store.announcements({});
+
+    expect(announcements).toEqual({
+      count: 0,
+      results: [],
+    });
+  });
+
+  it('handles not finding an announcement', async () => {
+    expect(await store.announcementByID('id')).toBeUndefined();
+  });
+
+  describe('filters', () => {
+    it('categories', async () => {
+      database = createDatabaseManager(testDbClient);
+      const categoryStore = (await initializePersistenceContext(database))
+        .categoriesStore;
+
+      await categoryStore.insert({
+        slug: 'category',
+        title: 'Category',
+      });
+
+      await categoryStore.insert({
+        slug: 'different',
+        title: 'A different category',
+      });
+
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        category: 'category',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        category: 'category',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id3',
+        publisher: 'publisher3',
+        title: 'title3',
+        excerpt: 'excerpt3',
+        body: 'body3',
+        category: 'different',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcements = await store.announcements({
+        category: 'category',
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id2',
+            publisher: 'publisher2',
+            title: 'title2',
+            excerpt: 'excerpt2',
+            body: 'body2',
+            category: {
+              slug: 'category',
+              title: 'Category',
+            },
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+          },
+          {
+            id: 'id',
+            publisher: 'publisher',
+            title: 'title',
+            excerpt: 'excerpt',
+            body: 'body',
+            category: {
+              slug: 'category',
+              title: 'Category',
+            },
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+          },
+        ],
+      });
+    });
+
+    // TODO: kurtaking - first testing says offset is not working as expected.
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('offset', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcements = await store.announcements({
+        offset: 1,
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id',
+            publisher: 'publisher',
+            title: 'title',
+            excerpt: 'excerpt',
+            body: 'body',
+            category: undefined,
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+          },
+        ],
+      });
+    });
+
+    // TODO: kurtaking - first testing says max is not working as expected.
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('max', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcements = await store.announcements({
+        max: 1,
+      });
+
+      expect(announcements).toEqual({
+        count: 2,
+        results: [
+          {
+            id: 'id2',
+            publisher: 'publisher2',
+            title: 'title2',
+            excerpt: 'excerpt2',
+            body: 'body2',
+            category: undefined,
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+          },
+        ],
+      });
+    });
+  });
+});

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -40,7 +40,7 @@ type AnnouncementsList = {
   results: Announcement[];
 };
 
-const timestampToDateTime = (input: Date | string): DateTime => {
+export const timestampToDateTime = (input: Date | string): DateTime => {
   if (typeof input === 'object') {
     return DateTime.fromJSDate(input).toUTC();
   }

--- a/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.test.ts
@@ -1,0 +1,65 @@
+import { Knex } from 'knex';
+import { CategoriesDatabase } from './CategoriesDatabase';
+import { TestDatabases } from '@backstage/backend-test-utils';
+import { initializePersistenceContext } from './persistenceContext';
+import { Category } from '../model';
+
+function createDatabaseManager(client: Knex, skipMigrations: boolean = false) {
+  return {
+    getClient: async () => client,
+    migrations: {
+      skip: skipMigrations,
+    },
+  };
+}
+
+describe('categories', () => {
+  const databases = TestDatabases.create();
+  let store: CategoriesDatabase;
+  let testDbClient: Knex<any, unknown[]>;
+  let database;
+
+  beforeAll(async () => {
+    testDbClient = await databases.init('SQLITE_3');
+    database = createDatabaseManager(testDbClient);
+    store = (await initializePersistenceContext(database)).categoriesStore;
+  });
+
+  afterEach(async () => {
+    await testDbClient('categories').delete();
+  });
+
+  it('should return an empty array when there are no categories', async () => {
+    const categories = await store.categories();
+    expect(categories).toEqual([]);
+  });
+
+  it('should return all categories in ascending order by title', async () => {
+    const category1: Category = { slug: 'category-1', title: 'Category 1' };
+    const category2: Category = { slug: 'category-2', title: 'Category 2' };
+    store.insert(category2);
+    store.insert(category1);
+
+    const categories = await store.categories();
+    expect(categories).toEqual([category1, category2]);
+  });
+
+  it('should delete a category', async () => {
+    const category: Category = { slug: 'category-1', title: 'Category 1' };
+    store.insert(category);
+
+    expect(await store.categories()).toEqual([category]);
+    await store.delete(category.slug);
+    expect(await store.categories()).toEqual([]);
+  });
+
+  it('should update a category', async () => {
+    const category: Category = { slug: 'category-1', title: 'Category 1' };
+    store.insert(category);
+
+    await store.update({ ...category, title: 'New Title' });
+    expect(await store.categories()).toEqual([
+      { slug: 'category-1', title: 'New Title' },
+    ]);
+  });
+});

--- a/plugins/announcements-backend/src/service/persistence/persistenceContext.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/persistenceContext.test.ts
@@ -1,0 +1,32 @@
+import { AnnouncementsDatabase } from './AnnouncementsDatabase';
+import { CategoriesDatabase } from './CategoriesDatabase';
+import {
+  PersistenceContext,
+  initializePersistenceContext,
+} from './persistenceContext';
+import { TestDatabases } from '@backstage/backend-test-utils';
+
+describe('initializePersistenceContext', () => {
+  const databases = TestDatabases.create();
+  const dbClient = databases.init('SQLITE_3');
+  const mockedDb = {
+    getClient: async () => dbClient,
+    migrations: {
+      skip: false,
+    },
+  };
+
+  let context: PersistenceContext;
+
+  beforeEach(async () => {
+    context = await initializePersistenceContext(mockedDb);
+  });
+
+  it('initializes the announcements store', async () => {
+    expect(context.announcementsStore).toBeInstanceOf(AnnouncementsDatabase);
+  });
+
+  it('initializes the categories store', async () => {
+    expect(context.categoriesStore).toBeInstanceOf(CategoriesDatabase);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2981,6 +2981,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-test-utils@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "@backstage/backend-test-utils@npm:0.2.7"
+  dependencies:
+    "@backstage/backend-app-api": ^0.5.6
+    "@backstage/backend-common": ^0.19.8
+    "@backstage/backend-plugin-api": ^0.6.6
+    "@backstage/config": ^1.1.1
+    "@backstage/errors": ^1.2.3
+    "@backstage/plugin-auth-node": ^0.4.0
+    "@backstage/types": ^1.1.1
+    better-sqlite3: ^8.0.0
+    express: ^4.17.1
+    fs-extra: ^10.0.1
+    knex: ^2.0.0
+    msw: ^1.0.0
+    mysql2: ^2.2.5
+    pg: ^8.3.0
+    testcontainers: ^8.1.2
+    textextensions: ^5.16.0
+    uuid: ^8.0.0
+  peerDependencies:
+    "@types/jest": "*"
+  checksum: 63803de67920d393a58f79018fb5584aa741e3cc24945b1655a83b6bd2a38184a3eb44e5e2aa9eb36a1de1601687c9ca6b222cbaf193946b13605691fbddaf7f
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-client@npm:^1.4.5":
   version: 1.4.5
   resolution: "@backstage/catalog-client@npm:1.4.5"
@@ -3563,6 +3590,27 @@ __metadata:
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
   checksum: dbf85118d34b29c19424f71cfb3918b63bc0243dd479df32227deec992686c006101395aef5a791887658d6d6543e0dbd9df4c5579fcbfd93284c79876924570
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-backend-node@npm:^1.2.10":
+  version: 1.2.10
+  resolution: "@backstage/plugin-search-backend-node@npm:1.2.10"
+  dependencies:
+    "@backstage/backend-common": ^0.19.8
+    "@backstage/backend-plugin-api": ^0.6.6
+    "@backstage/backend-tasks": ^0.5.11
+    "@backstage/config": ^1.1.1
+    "@backstage/errors": ^1.2.3
+    "@backstage/plugin-permission-common": ^0.7.9
+    "@backstage/plugin-search-common": ^1.2.7
+    "@types/lunr": ^2.3.3
+    lodash: ^4.17.21
+    lunr: ^2.3.9
+    ndjson: ^2.0.0
+    uuid: ^8.3.2
+    winston: ^3.2.1
+  checksum: fc76a3ee76228d4f9d45faa8301c5d1c88f0fb00b4956cd43fd1e89c34de64a9e270a5588faf8782e5e59860635f44ffd9d21b3d4019a87b6f080fd8d4b8bf87
   languageName: node
   linkType: hard
 
@@ -6014,6 +6062,7 @@ __metadata:
   resolution: "@procore-oss/backstage-plugin-announcements-backend@workspace:plugins/announcements-backend"
   dependencies:
     "@backstage/backend-common": ^0.19.8
+    "@backstage/backend-test-utils": ^0.2.7
     "@backstage/cli": ^0.23.1
     "@backstage/config": ^1.1.1
     "@backstage/core-plugin-api": ^1.7.0
@@ -6021,7 +6070,9 @@ __metadata:
     "@backstage/plugin-auth-node": ^0.4.0
     "@backstage/plugin-permission-common": ^0.7.9
     "@backstage/plugin-permission-node": ^0.7.17
+    "@backstage/plugin-search-backend-node": ^1.2.10
     "@backstage/plugin-search-common": ^1.2.7
+    "@backstage/test-utils": ^1.4.4
     "@procore-oss/backstage-plugin-announcements-common": ^0.1.2
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.15
@@ -6747,6 +6798,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/archiver@npm:^5.3.1":
+  version: 5.3.4
+  resolution: "@types/archiver@npm:5.3.4"
+  dependencies:
+    "@types/readdir-glob": "*"
+  checksum: 4ef27b99091ada9b8f13017d5b9e6d42a439e35a7858b30e040c408e081d98d8db6307b0762500288b5da38cab9823c4756b6abae1fdd2658d42bfb09eb7c5fb
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^4.2.0":
   version: 4.2.2
   resolution: "@types/aria-query@npm:4.2.2"
@@ -6903,6 +6963,16 @@ __metadata:
     "@types/docker-modem": "*"
     "@types/node": "*"
   checksum: 6a8472622861fb0c97908963a8236d6e439c9feefc845b866326272ad0e5c33f537206fb4633424c5e3c8ec63559cb14bc737e2f88f0fcdf11496a9162d5b139
+  languageName: node
+  linkType: hard
+
+"@types/dockerode@npm:^3.3.8":
+  version: 3.3.21
+  resolution: "@types/dockerode@npm:3.3.21"
+  dependencies:
+    "@types/docker-modem": "*"
+    "@types/node": "*"
+  checksum: 025c97cd2549f1b3f0dc6e117e24e3b7e56dcf3e482e2abe5f2d6961e56e637b0e1f1b4f032e065cd7245302064ac3ccdb9c7dfdb0fe43a5bfb2b5f4ccbf4a8d
   languageName: node
   linkType: hard
 
@@ -7124,6 +7194,13 @@ __metadata:
   version: 5.1.1
   resolution: "@types/lru-cache@npm:5.1.1"
   checksum: e1d6c0085f61b16ec5b3073ec76ad1be4844ea036561c3f145fc19f71f084b58a6eb600b14128aa95809d057d28f1d147c910186ae51219f58366ffd2ff2e118
+  languageName: node
+  linkType: hard
+
+"@types/lunr@npm:^2.3.3":
+  version: 2.3.6
+  resolution: "@types/lunr@npm:2.3.6"
+  checksum: 9754a78f13ca13ffd8b0976409fc9071e51ada05298a3a582d706d0c5b522a529bcda19cf4bdbf599fc47ddf6de9131f06e9d3c76d1e2beafc14b48d65e61926
   languageName: node
   linkType: hard
 
@@ -7374,6 +7451,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/readdir-glob@npm:*":
+  version: 1.1.3
+  resolution: "@types/readdir-glob@npm:1.1.3"
+  dependencies:
+    "@types/node": "*"
+  checksum: b4ac9fa05d44f219116027afbcc7dc717f122079e9e173f63c2267d4cbc35e267b46872313d7797f2840fd5a4337204ef27f8fd091ba702c813ff8ca0bf380ae
+  languageName: node
+  linkType: hard
+
 "@types/request@npm:^2.47.1":
   version: 2.48.8
   resolution: "@types/request@npm:2.48.8"
@@ -7460,12 +7546,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ssh2-streams@npm:*":
+  version: 0.1.11
+  resolution: "@types/ssh2-streams@npm:0.1.11"
+  dependencies:
+    "@types/node": "*"
+  checksum: 2e70f28afccb6d8c7af0a726212ee10a693b4880b69a36aa204dc37a854a9ca0b378450584d0fc818acaa019ed82ac443f498cd70335c81c0e49c99bc17f138c
+  languageName: node
+  linkType: hard
+
 "@types/ssh2@npm:*":
   version: 1.11.6
   resolution: "@types/ssh2@npm:1.11.6"
   dependencies:
     "@types/node": "*"
   checksum: 4812694de5444802f7386da7882da9072a6d63b5b634eb59fdca39e8f7ad4964bcefe7844d375d594cb979a0804e24aea273098bdbb84e7e23a9d3b5698d3936
+  languageName: node
+  linkType: hard
+
+"@types/ssh2@npm:^0.5.48":
+  version: 0.5.52
+  resolution: "@types/ssh2@npm:0.5.52"
+  dependencies:
+    "@types/node": "*"
+    "@types/ssh2-streams": "*"
+  checksum: bc1c76ac727ad73ddd59ba849cf0ea3ed2e930439e7a363aff24f04f29b74f9b1976369b869dc9a018223c9fb8ad041c09a0f07aea8cf46a8c920049188cddae
   languageName: node
   linkType: hard
 
@@ -8390,6 +8495,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"archiver@npm:^5.3.1":
+  version: 5.3.2
+  resolution: "archiver@npm:5.3.2"
+  dependencies:
+    archiver-utils: ^2.1.0
+    async: ^3.2.4
+    buffer-crc32: ^0.2.1
+    readable-stream: ^3.6.0
+    readdir-glob: ^1.1.2
+    tar-stream: ^2.2.0
+    zip-stream: ^4.1.0
+  checksum: 7d3b9b9b51cf54d88c89fbca9b0847c120bfcf9776c7025c52dd0b62f6603dc63dc0f3f1a09582f936f67e3906b46d58954cc762a255be45e8d3e14e3cb0b0b1
+  languageName: node
+  linkType: hard
+
 "are-we-there-yet@npm:^3.0.0":
   version: 3.0.1
   resolution: "are-we-there-yet@npm:3.0.1"
@@ -8546,7 +8666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:^0.2.4, asn1@npm:~0.2.3":
+"asn1@npm:^0.2.4, asn1@npm:^0.2.6, asn1@npm:~0.2.3":
   version: 0.2.6
   resolution: "asn1@npm:0.2.6"
   dependencies:
@@ -8602,7 +8722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3":
+"async@npm:^3.2.3, async@npm:^3.2.4":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
   checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
@@ -8857,7 +8977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^8.7.0":
+"better-sqlite3@npm:^8.0.0, better-sqlite3@npm:^8.7.0":
   version: 8.7.0
   resolution: "better-sqlite3@npm:8.7.0"
   dependencies:
@@ -9212,6 +9332,13 @@ __metadata:
   version: 0.0.3
   resolution: "buildcheck@npm:0.0.3"
   checksum: baf30605c56e80c2ca0502e40e18f2ebc7075bb4a861c941c0b36cd468b27957ed11a62248003ce99b9e5f91a7dfa859b30aad4fa50f0090c77a6f596ba20e6d
+  languageName: node
+  linkType: hard
+
+"buildcheck@npm:~0.0.6":
+  version: 0.0.6
+  resolution: "buildcheck@npm:0.0.6"
+  checksum: ad61759dc98d62e931df2c9f54ccac7b522e600c6e13bdcfdc2c9a872a818648c87765ee209c850f022174da4dd7c6a450c00357c5391705d26b9c5807c2a076
   languageName: node
   linkType: hard
 
@@ -10133,6 +10260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cpu-features@npm:~0.0.8":
+  version: 0.0.9
+  resolution: "cpu-features@npm:0.0.9"
+  dependencies:
+    buildcheck: ~0.0.6
+    nan: ^2.17.0
+    node-gyp: latest
+  checksum: 1ff6045a16d32d9667d5dd69c7d485944494d3378ac9381c52bca772bd0c948812eaeda55a76ef09212b0c0e0c575e5d53221899ce51692b1196089452c5aef1
+  languageName: node
+  linkType: hard
+
 "crc-32@npm:^1.2.0":
   version: 1.2.2
   resolution: "crc-32@npm:1.2.2"
@@ -11029,6 +11167,15 @@ __metadata:
   dependencies:
     "@leichtgewicht/ip-codec": ^2.0.1
   checksum: a169963848e8539dfd8a19058562f9e1c15c0f82cbf76fa98942f11c46f3c74e7e7c82e3a8a5182d4c9e6ff19e21be738dbd098a876dde755d3aedd2cc730880
+  languageName: node
+  linkType: hard
+
+"docker-compose@npm:^0.23.17":
+  version: 0.23.19
+  resolution: "docker-compose@npm:0.23.19"
+  dependencies:
+    yaml: ^1.10.2
+  checksum: 1704825954ec8645e4b099cc2641531955eef5a8a9729c885fab7067ae4d7935c663252e51b49878397e51cd5a3efcf2f13c8460e252aa39d14a0722c0bacfe5
   languageName: node
   linkType: hard
 
@@ -12963,7 +13110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:10.1.0, fs-extra@npm:^10.0.0":
+"fs-extra@npm:10.1.0, fs-extra@npm:^10.0.0, fs-extra@npm:^10.0.1":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -13161,6 +13308,13 @@ __metadata:
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-port@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "get-port@npm:5.1.1"
+  checksum: 0162663ffe5c09e748cd79d97b74cd70e5a5c84b760a475ce5767b357fb2a57cb821cee412d646aa8a156ed39b78aab88974eddaa9e5ee926173c036c0713787
   languageName: node
   linkType: hard
 
@@ -16605,6 +16759,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 176719e24fcce7d3cf1baccce9dd5633cd8bdc1f41ebe6a180112e5ee99d80373fe2454f5d4624d437e5a8319698ca6837b9950566e15d2cae5f2a543a3db4b8
+  languageName: node
+  linkType: hard
+
 "luxon@npm:^3.0.0, luxon@npm:^3.2.0, luxon@npm:^3.2.1":
   version: 3.3.0
   resolution: "luxon@npm:3.3.0"
@@ -17668,7 +17829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.3.2":
+"msw@npm:^1.0.0, msw@npm:^1.3.2":
   version: 1.3.2
   resolution: "msw@npm:1.3.2"
   dependencies:
@@ -17766,6 +17927,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.17.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 4fe42f58456504eab3105c04a5cffb72066b5f22bd45decf33523cb17e7d6abc33cca2a19829407b9000539c5cb25f410312d4dc5b30220167a3594896ea6a0a
+  languageName: node
+  linkType: hard
+
 "nano-css@npm:^5.3.1":
   version: 5.3.5
   resolution: "nano-css@npm:5.3.5"
@@ -17805,6 +17975,21 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
+  languageName: node
+  linkType: hard
+
+"ndjson@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ndjson@npm:2.0.0"
+  dependencies:
+    json-stringify-safe: ^5.0.1
+    minimist: ^1.2.5
+    readable-stream: ^3.6.0
+    split2: ^3.0.0
+    through2: ^4.0.0
+  bin:
+    ndjson: cli.js
+  checksum: f847a51a2275b8a6a1bfdb24095183836b71c3085670161678c9922bc59644f04e53ced385e549a5565fdc44c28e206bd3f2199d12525028f843a86b680c4446
   languageName: node
   linkType: hard
 
@@ -19521,6 +19706,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"properties-reader@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "properties-reader@npm:2.3.0"
+  dependencies:
+    mkdirp: ^1.0.4
+  checksum: cbf59e862dc507f8ce1f8d7641ed9737119f16a1d4dad8e79f17b303aaca1c6af7d36ddfef0f649cab4d200ba4334ac159af0b238f6978a085f5b1b5126b6cc3
+  languageName: node
+  linkType: hard
+
 "property-information@npm:^5.0.0":
   version: 5.6.0
   resolution: "property-information@npm:5.6.0"
@@ -20154,6 +20348,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:3, readable-stream@npm:^3.0.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
@@ -20186,6 +20391,15 @@ __metadata:
   dependencies:
     minimatch: ^5.1.0
   checksum: 1e5f701d3c94af5653e1736dfef99e991869c6e1c87bf08835d8c641f767e73ae25b829d3d1f8504fab8cad49b70b718ef960d3afee5be45cd779ccaeb264ed4
+  languageName: node
+  linkType: hard
+
+"readdir-glob@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "readdir-glob@npm:1.1.3"
+  dependencies:
+    minimatch: ^5.1.0
+  checksum: 1dc0f7440ff5d9378b593abe9d42f34ebaf387516615e98ab410cf3a68f840abbf9ff1032d15e0a0dbffa78f9e2c46d4fafdbaac1ca435af2efe3264e3f21874
   languageName: node
   linkType: hard
 
@@ -21645,6 +21859,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split2@npm:^3.0.0":
+  version: 3.2.2
+  resolution: "split2@npm:3.2.2"
+  dependencies:
+    readable-stream: ^3.0.0
+  checksum: 8127ddbedd0faf31f232c0e9192fede469913aa8982aa380752e0463b2e31c2359ef6962eb2d24c125bac59eeec76873678d723b1c7ff696216a1cd071e3994a
+  languageName: node
+  linkType: hard
+
 "split2@npm:^4.1.0":
   version: 4.1.0
   resolution: "split2@npm:4.1.0"
@@ -21673,6 +21896,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssh-remote-port-forward@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "ssh-remote-port-forward@npm:1.0.4"
+  dependencies:
+    "@types/ssh2": ^0.5.48
+    ssh2: ^1.4.0
+  checksum: c6c04c5ddfde7cb06e9a8655a152bd28fe6771c6fe62ff0bc08be229491546c410f30b153c968b8d6817a57d38678a270c228f30143ec0fe1be546efc4f6b65a
+  languageName: node
+  linkType: hard
+
 "ssh2@npm:^1.11.0":
   version: 1.11.0
   resolution: "ssh2@npm:1.11.0"
@@ -21687,6 +21920,23 @@ __metadata:
     nan:
       optional: true
   checksum: e40cb9f171741a807c170dc555078aa8c49dc93dd36fc9c8be026fce1cfd31f0d37078d9b60a0f2cfb11d0e007ed5407376b72f8a0ef9f2cb89574632bbfb824
+  languageName: node
+  linkType: hard
+
+"ssh2@npm:^1.4.0":
+  version: 1.14.0
+  resolution: "ssh2@npm:1.14.0"
+  dependencies:
+    asn1: ^0.2.6
+    bcrypt-pbkdf: ^1.0.2
+    cpu-features: ~0.0.8
+    nan: ^2.17.0
+  dependenciesMeta:
+    cpu-features:
+      optional: true
+    nan:
+      optional: true
+  checksum: c583527950312716f1b620d5120e3c3e241f8cc221f19fc88fd3d561c6020c1009532438f2177a2e706223d91842deff137d93e00832b7b9016593da9a00fb89
   languageName: node
   linkType: hard
 
@@ -22279,7 +22529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^2.0.0":
+"tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
   dependencies:
@@ -22404,6 +22654,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"testcontainers@npm:^8.1.2":
+  version: 8.16.0
+  resolution: "testcontainers@npm:8.16.0"
+  dependencies:
+    "@balena/dockerignore": ^1.0.2
+    "@types/archiver": ^5.3.1
+    "@types/dockerode": ^3.3.8
+    archiver: ^5.3.1
+    byline: ^5.0.0
+    debug: ^4.3.4
+    docker-compose: ^0.23.17
+    dockerode: ^3.3.1
+    get-port: ^5.1.1
+    properties-reader: ^2.2.0
+    ssh-remote-port-forward: ^1.0.4
+    tar-fs: ^2.1.1
+  checksum: 2fb8250591691a4bd86640b53e13236ad507ba9e03ac3043683de5e9dd632bc29d52827c22ccfe2b0d28dec6896cbaa56dcb153ce65f7f74212ddefc204e8d6a
+  languageName: node
+  linkType: hard
+
 "text-hex@npm:1.0.x":
   version: 1.0.0
   resolution: "text-hex@npm:1.0.0"
@@ -22415,6 +22685,13 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: b6937a38c80c7f84d9c11dd75e49d5c44f71d95e810a3250bd1f1797fc7117c57698204adf676b71497acc205d769d65c16ae8fa10afad832ae1322630aef10a
+  languageName: node
+  linkType: hard
+
+"textextensions@npm:^5.16.0":
+  version: 5.16.0
+  resolution: "textextensions@npm:5.16.0"
+  checksum: d2abd5c962760046aa85d9ca542bd8bdb451370fc0a5e5f807aa80dd2f50175ec10d5ce9d28ae96968aaf6a1b1bea254cf4715f24852d0dcf29c6a60af7f793c
   languageName: node
   linkType: hard
 
@@ -22440,6 +22717,15 @@ __metadata:
   version: 3.0.1
   resolution: "throttle-debounce@npm:3.0.1"
   checksum: e34ef638e8df3a9154249101b68afcbf2652a139c803415ef8a2f6a8bc577bcd4d79e4bb914ad3cd206523ac78b9fb7e80885bfa049f64fbb1927f99d98b5736
+  languageName: node
+  linkType: hard
+
+"through2@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "through2@npm:4.0.2"
+  dependencies:
+    readable-stream: 3
+  checksum: ac7430bd54ccb7920fd094b1c7ff3e1ad6edd94202e5528331253e5fde0cc56ceaa690e8df9895de2e073148c52dfbe6c4db74cacae812477a35660090960cc0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR adds unit tests for the **announcements-backend** plugin. There is an open [issue](https://github.com/procore-oss/backstage-plugin-announcements/issues/20) requesting help with unit testing the frontend. 

## Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

## Current State

The router is partially tested. There are no other unit tests at this time.

<img width="1714" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/c58a19be-5bbd-4c98-8dd6-a5f95fba4202">

## Updates from PR

**General overview of progress**
<img width="1713" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/73b32bfa-9e37-465a-9330-e1d160015849">


**Database**
<img width="1696" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/cc0c2af1-f6d9-4814-9639-8261b788f303">

**Search**
<img width="1719" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/517b5439-5e9f-4a9e-9940-ae4453192d01">

**Persistence context & service router**
<img width="1715" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/e4808a4f-e504-433b-b57d-bb31305b225d">


