### PR TITLE
fix: set correct database migrations folder path

### DIFF
--- a/.changeset/mean-plants-wait.md
+++ b/.changeset/mean-plants-wait.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+set correct build database migrations folder path

--- a/plugins/announcements-backend/package.json
+++ b/plugins/announcements-backend/package.json
@@ -67,6 +67,6 @@
   },
   "files": [
     "dist",
-    "migrations/**/*.{js,d.ts}"
+    "db/migrations/**/*.{js,d.ts}"
   ]
 }


### PR DESCRIPTION
"Since this change[ [insert hyperlink](https://github.com/procore-oss/backstage-plugin-announcements/commit/4968543f32f180475ce9c3a6be6cd3b00512d5f0)], the migrations folder isn't correct for the build.

This change fixes this error during Backstage startup:

```log
[1] Backend failed to start up [Error: ENOENT: no such file or directory, scandir '/home/io/workspace/elca-backstage/node_modules/@procore-oss/backstage-plugin-announcements-backend/db/migrations']
```