### PR TITLE
feat: allow overriding length of announcement title

### DIFF
--- a/.changeset/sour-coins-give.md
+++ b/.changeset/sour-coins-give.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Allows a user to specify the title length for the list of Announcement cards. This is useful if you would like to truncate all titles to keep cards consistent

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,21 @@
 - [Integration with `@backstage/plugin-search`](search.md)
 - [Display latest announcements on a page](latest-announcements-on-page.md)
 - [Display a banner for the latest announcement](latest-announcement-banner.md)
+
+## Customization
+
+### Overriding the AnnouncementCard
+
+It is possible to specify the length of the title for announcements rendered on the `AnnouncementsPage`. You can do this by passing a `cardOptions` prop to the `AnnouncementsPage` component. The `cardOptions` prop accepts an object with the following properties:
+
+```ts
+{
+  titleLength: number; // defaults to 50
+}
+```
+
+Example
+
+```tsx
+<AnnouncementsPage cardOptions={{ titleLength: 10 }} />
+```

--- a/plugins/announcements/dev/index.tsx
+++ b/plugins/announcements/dev/index.tsx
@@ -65,7 +65,7 @@ createDevApp()
   .registerPlugin(fakeCatalogPlugin)
   .registerPlugin(announcementsPlugin)
   .addPage({
-    element: <AnnouncementsPage />,
+    element: <AnnouncementsPage cardOptions={{ titleLength: 50 }} />,
     title: 'Root Page',
     path: '/announcements',
   })

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  MockPermissionApi,
+  TestApiProvider,
+  renderInTestApp,
+} from '@backstage/test-utils';
+import { AnnouncementsPage } from './AnnouncementsPage';
+import { rootRouteRef } from '../../routes';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import { announcementsApiRef } from '../../api';
+import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
+
+const mockAnnouncements = [
+  {
+    id: '0',
+    publisher: 'default:user/user',
+    title: 'announcement-title',
+    excerpt: 'excerpt',
+    body: 'body',
+    created_at: 'created_at',
+  },
+];
+
+describe('AnnouncementsPage', () => {
+  const mockPermissionApi = new MockPermissionApi();
+  const mockAnnouncementsApi = {
+    announcements: jest.fn().mockResolvedValue({
+      count: 0,
+      results: mockAnnouncements,
+    }),
+  };
+
+  const mockCatalogApi = {
+    getEntities: async () => ({ items: [] }),
+  };
+
+  it('should render', async () => {
+    const rendered = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [permissionApiRef, mockPermissionApi],
+          [announcementsApiRef, mockAnnouncementsApi],
+          [catalogApiRef, mockCatalogApi],
+        ]}
+      >
+        <AnnouncementsPage themeId="home" title="Announcements" />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/announcements': rootRouteRef,
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+    expect(rendered.getByText('Announcements')).toBeInTheDocument();
+  });
+
+  describe('AnnouncementCard', () => {
+    it('should render announcement card title', async () => {
+      const rendered = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [permissionApiRef, mockPermissionApi],
+            [announcementsApiRef, mockAnnouncementsApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <AnnouncementsPage themeId="home" title="Announcements" />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/announcements': rootRouteRef,
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(rendered.getByText('Announcements')).toBeInTheDocument();
+      expect(rendered.getByText('announcement-title')).toBeInTheDocument();
+      expect(rendered.getByText('excerpt')).toBeInTheDocument();
+    });
+
+    it('should render with overridden announcement card length', async () => {
+      const rendered = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [permissionApiRef, mockPermissionApi],
+            [announcementsApiRef, mockAnnouncementsApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <AnnouncementsPage
+            themeId="home"
+            title="Announcements"
+            cardOptions={{ titleLength: 13 }}
+          />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/announcements': rootRouteRef,
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(rendered.getByText('Announcements')).toBeInTheDocument();
+      expect(rendered.queryByText('announcement-title')).toBeNull();
+      expect(rendered.getByText('announcement-')).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -65,9 +65,11 @@ const useStyles = makeStyles(theme => ({
 const AnnouncementCard = ({
   announcement,
   onDelete,
+  options: { titleLength = 50 },
 }: {
   announcement: Announcement;
   onDelete: () => void;
+  options: AnnouncementCardProps;
 }) => {
   const classes = useStyles();
   const announcementsLink = useRouteRef(rootRouteRef);
@@ -81,7 +83,7 @@ const AnnouncementCard = ({
       className={classes.cardHeader}
       to={viewAnnouncementLink({ id: announcement.id })}
     >
-      {announcement.title}
+      {announcement.title.substring(0, titleLength)}
     </Link>
   );
   const subTitle = (
@@ -174,9 +176,11 @@ const AnnouncementCard = ({
 const AnnouncementsGrid = ({
   maxPerPage,
   category,
+  cardTitleLength,
 }: {
   maxPerPage: number;
   category?: string;
+  cardTitleLength?: number;
 }) => {
   const classes = useStyles();
   const announcementsApi = useApi(announcementsApiRef);
@@ -230,11 +234,12 @@ const AnnouncementsGrid = ({
   return (
     <>
       <ItemCardGrid>
-        {announcementsList?.results!.map((announcement, index) => (
+        {announcementsList?.results!.map(announcement => (
           <AnnouncementCard
-            key={index}
+            key={announcement.id}
             announcement={announcement}
             onDelete={() => openDeleteDialog(announcement)}
+            options={{ titleLength: cardTitleLength }}
           />
         ))}
       </ItemCardGrid>
@@ -258,12 +263,17 @@ const AnnouncementsGrid = ({
   );
 };
 
+type AnnouncementCardProps = {
+  titleLength?: number;
+};
+
 type AnnouncementsPageProps = {
   themeId: string;
   title: string;
   subtitle?: ReactNode;
   maxPerPage?: number;
   category?: string;
+  cardOptions?: AnnouncementCardProps;
 };
 
 export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
@@ -296,6 +306,7 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
         <AnnouncementsGrid
           maxPerPage={props.maxPerPage ?? 10}
           category={props.category ?? queryParams.get('category') ?? undefined}
+          cardTitleLength={props.cardOptions?.titleLength}
         />
       </Content>
     </Page>

--- a/plugins/announcements/src/components/Router.tsx
+++ b/plugins/announcements/src/components/Router.tsx
@@ -21,6 +21,9 @@ type RouterProps = {
   themeId?: string;
   title?: string;
   subtitle?: string;
+  cardOptions?: {
+    titleLength: number | undefined;
+  };
 };
 
 export const Router = (props: RouterProps) => {


### PR DESCRIPTION
Solves https://github.com/procore-oss/backstage-plugin-announcements/issues/117

### Details:

Allow the user to override the title length in an AnnouncementCard

### Screenshots:

Seeded data with the default length -> no change to end user

`<AnnouncementsPage />`

<img width="1499" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/437aa96b-8572-49f7-b32d-3dd699025ec6">

`<AnnouncementsPage cardOptions={{ titleLength: 1 }} />`

<img width="1491" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/c5f2be06-59ef-4390-b11c-d00f5b36850d">

`<AnnouncementsPage cardOptions={{ titleLength: 5 }} />`

<img width="1495" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/116b50d7-2abd-4ff3-95ed-c602d3b4d35d">

### Code coverage

We officially have some unit tests for the frontend 🎉 

**Before** 

<img width="1711" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/5f3f4f12-4426-4d17-ae92-975807874562">

**After**

<img width="1716" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/d74d44e5-baa0-493c-bbd6-6a33134a9b79">



Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
