### PR TITLE
feat: truncated card titles includes ellipsis and tooltip with full title

### DIFF
--- a/.changeset/stale-vans-glow.md
+++ b/.changeset/stale-vans-glow.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Announcement cards will now display truncated titles with an ellipsis. Hovering over the title will display a tooltip with the full title.

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -9,6 +9,7 @@ import { rootRouteRef } from '../../routes';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { announcementsApiRef } from '../../api';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
+import { fireEvent } from '@testing-library/react';
 
 const mockAnnouncements = [
   {
@@ -103,7 +104,12 @@ describe('AnnouncementsPage', () => {
       );
       expect(rendered.getByText('Announcements')).toBeInTheDocument();
       expect(rendered.queryByText('announcement-title')).toBeNull();
-      expect(rendered.getByText('announcement-')).toBeInTheDocument();
+      expect(rendered.getByText('announcement-...')).toBeInTheDocument();
+
+      fireEvent.mouseOver(rendered.getByText('announcement-...'));
+      expect(
+        await rendered.findByText('announcement-title'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -90,12 +90,18 @@ const AnnouncementCard = ({
 
   const publisherRef = parseEntityRef(announcement.publisher);
   const title = (
-    <Link
-      className={classes.cardHeader}
-      to={viewAnnouncementLink({ id: announcement.id })}
+    <Tooltip
+      title={announcement.title}
+      disableFocusListener
+      data-testid="announcement-card-title-tooltip"
     >
-      {truncate(announcement.title, titleLength)}
-    </Link>
+      <Link
+        className={classes.cardHeader}
+        to={viewAnnouncementLink({ id: announcement.id })}
+      >
+        {truncate(announcement.title, titleLength)}
+      </Link>
+    </Tooltip>
   );
   const subTitle = (
     <>

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -36,6 +36,7 @@ import {
   ListItemIcon,
   Menu,
   MenuItem,
+  Tooltip,
   makeStyles,
 } from '@material-ui/core';
 import {
@@ -62,6 +63,16 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+/**
+ * Truncate text to a given length and add ellipsis
+ * @param text the text to truncate
+ * @param length the length to truncate to
+ * @returns the truncated text
+ */
+const truncate = (text: string, length: number) => {
+  return text.length > length ? `${text.substring(0, length)}...` : text;
+};
+
 const AnnouncementCard = ({
   announcement,
   onDelete,
@@ -83,7 +94,7 @@ const AnnouncementCard = ({
       className={classes.cardHeader}
       to={viewAnnouncementLink({ id: announcement.id })}
     >
-      {announcement.title.substring(0, titleLength)}
+      {truncate(announcement.title, titleLength)}
     </Link>
   );
   const subTitle = (


### PR DESCRIPTION
Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

Details:

- truncated title now includes ellipsis
- hovering over title will display toolip with the full title

<img width="1506" alt="image" src="https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/de97890a-ac9f-4ca5-aaa5-8b310d9ae331">
