### PR TITLE
Use EntityDisplayName

### DIFF
--- a/.changeset/new-bikes-admire.md
+++ b/.changeset/new-bikes-admire.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Use Entity display name

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { parseEntityRef } from '@backstage/catalog-model';
 import {
+  EntityDisplayName,
   EntityPeekAheadPopover,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
@@ -107,7 +108,9 @@ const AnnouncementCard = ({
     <>
       By{' '}
       <EntityPeekAheadPopover entityRef={announcement.publisher}>
-        <Link to={entityLink(publisherRef)}>{publisherRef.name}</Link>
+        <Link to={entityLink(publisherRef)}>
+          <EntityDisplayName entityRef={announcement.publisher} hideIcon />
+        </Link>
       </EntityPeekAheadPopover>
       {announcement.category && (
         <>


### PR DESCRIPTION
Checklist:

* [X] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

This PR implement this: https://github.com/procore-oss/backstage-plugin-announcements/issues/126

Default component already supports displaying `userEntity` on hover. Let's see if it still makes sense to use the `<Link>` component.

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
