### PR TITLE
fix: export announcementsApiRef

### DIFF
--- a/.changeset/six-trainers-hope.md
+++ b/.changeset/six-trainers-hope.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+export announcementsApiRef

--- a/plugins/announcements/src/index.ts
+++ b/plugins/announcements/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plugin';
+export { announcementsApiRef } from './api';


### PR DESCRIPTION
Details:

Export the `announcementsApiRef`. Users need this to implement tests on their end. 

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green