### PR TITLE
wip: Add severity level

### DIFF
--- a/plugins/announcements/src/api.ts
+++ b/plugins/announcements/src/api.ts
@@ -36,6 +36,7 @@ export type CreateAnnouncementRequest = Omit<
   'id' | 'category' | 'created_at'
 > & {
   category?: string;
+  severity: string;
 };
 
 export type CreateCategoryRequest = {

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -5,9 +5,17 @@ import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   Button,
   CircularProgress,
+  ListItemIcon,
   makeStyles,
+  MenuItem,
+  Select,
   TextField,
 } from '@material-ui/core';
+import LoopIcon from '@material-ui/icons/Loop';
+import BuildIcon from '@material-ui/icons/Build';
+import AnnouncementIcon from '@material-ui/icons/Announcement';
+import ErrorIcon from '@material-ui/icons/Error';
+import WarningIcon from '@material-ui/icons/Warning';
 import {
   Announcement,
   announcementsApiRef,
@@ -38,7 +46,9 @@ export const AnnouncementForm = ({
   const [form, setForm] = React.useState({
     ...initialData,
     category: initialData.category?.slug,
+    severity: 'info',
   });
+  const [selectedOption, setSelectedOption] = React.useState('info');
   const [loading, setLoading] = React.useState(false);
 
   const announcementsApi = useApi(announcementsApiRef);
@@ -52,6 +62,10 @@ export const AnnouncementForm = ({
       ...form,
       [event.target.id]: event.target.value,
     });
+  };
+
+  const handleSelectChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSelectedOption(event.target.value as string);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -116,6 +130,44 @@ export const AnnouncementForm = ({
             />
           )}
         />
+        <Select
+          value={selectedOption}
+          onChange={handleSelectChange}
+          labelId="demo-simple-select-placeholder-label-label"
+          variant="outlined"
+          fullWidth
+        >
+          <MenuItem value="info">
+            <ListItemIcon>
+              <AnnouncementIcon />
+            </ListItemIcon>
+            Info
+          </MenuItem>
+          <MenuItem value="important">
+            <ListItemIcon>
+              <ErrorIcon />
+            </ListItemIcon>
+            Important
+          </MenuItem>
+          <MenuItem value="critical">
+            <ListItemIcon>
+              <WarningIcon />
+            </ListItemIcon>
+            Critical
+          </MenuItem>
+          <MenuItem value="upgrade">
+            <ListItemIcon>
+              <LoopIcon />
+            </ListItemIcon>
+            Upgrade
+          </MenuItem>
+          <MenuItem value="maintenance">
+            <ListItemIcon>
+              <BuildIcon />
+            </ListItemIcon>
+            Maintenance
+          </MenuItem>
+        </Select>
         <TextField
           id="excerpt"
           type="text"


### PR DESCRIPTION
Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

The purpose of this draft is to add the notion of announcements criticality level. I think this data has the same lifecycle as an announcement, meaning that I plan to add a new column `level` in  `announcements` table.

This new entry will allow us to implement this timeline: https://github.com/procore-oss/backstage-plugin-announcements/issues/119 and reintroduce a different color banner based on the level.


https://github.com/procore-oss/backstage-plugin-announcements/assets/55390114/c3a40b3f-99d8-4710-8cf1-0635fd3dc039


<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
