### PR TITLE
fix: add exporting collator back to @procore-oss/backstage-plugin-announcements-backend

### DIFF
--- a/.changeset/good-taxis-smile.md
+++ b/.changeset/good-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+It was a mistake to remove the AnnouncementsCollatorFactory. Users can only migrate to the new search module for annoucements if they are leveraging the new backend system.

--- a/plugins/announcements-backend/src/index.ts
+++ b/plugins/announcements-backend/src/index.ts
@@ -1,3 +1,4 @@
 export * from './service/router';
 export { AnnouncementsClient, type Announcement } from './api';
 export { buildAnnouncementsContext } from './service/announcementsContextBuilder';
+export { AnnouncementCollatorFactory } from './search';

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
@@ -16,7 +16,8 @@ type AnnouncementCollatorOptions = {
 };
 
 /**
- * @deprecated Import from `@procore-oss/plugin-search-backend-module-announcements` instead
+ * @remark This can replaced by the module `@procore-oss/plugin-search-backend-module-announcements` if using
+ * the new backend system. Note the module does not export the `AnnouncementCollatorFactory` class directly.
  */
 export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
   public readonly type: string = 'announcements';


### PR DESCRIPTION
I'll chalk this up as a learning opportunity with the new backend architecture for Backstage. A backend module ends with having a single export, the module itself, so the deprecation telling the end user to migrate is incorrect. 

The search module for announcements does not export the collator. You should only migrate if leveraging the new backend system.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
