### PR TITLE
Add missing display name

### DIFF
--- a/.changeset/tame-kids-thank.md
+++ b/.changeset/tame-kids-thank.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Use display name in Announcement Card

--- a/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { parseEntityRef } from '@backstage/catalog-model';
 import {
+  EntityDisplayName,
   EntityPeekAheadPopover,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
@@ -42,7 +43,9 @@ const AnnouncementDetails = ({
     <span>
       By{' '}
       <EntityPeekAheadPopover entityRef={announcement.publisher}>
-        <Link to={entityLink(publisherRef)}>{publisherRef.name}</Link>
+        <Link to={entityLink(publisherRef)}>
+          <EntityDisplayName entityRef={announcement.publisher} hideIcon />
+        </Link>
       </EntityPeekAheadPopover>
       , {DateTime.fromISO(announcement.created_at).toRelative()}
     </span>


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

I miss this part (https://github.com/procore-oss/backstage-plugin-announcements/pull/160) when we replaced userEntity by DisplayName
