### PR TITLE
fix: package name - release @procore-oss/backstage-plugin-announcements-react

### DIFF
--- a/.changeset/lazy-seas-wait.md
+++ b/.changeset/lazy-seas-wait.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-react': patch
+---
+
+New react plugin to support new architecture

--- a/plugins/announcements-react/README.md
+++ b/plugins/announcements-react/README.md
@@ -1,3 +1,3 @@
-# @procore-oss/plugin-announcements-react
+# @procore-oss/backstage-plugin-announcements-react
 
 Welcome to the web library package for the announcements plugin!

--- a/plugins/announcements-react/package.json
+++ b/plugins/announcements-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@procore-oss/plugin-announcements-react",
+  "name": "@procore-oss/backstage-plugin-announcements-react",
   "description": "Web library for the announcements plugin",
   "version": "0.1.0",
   "main": "src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5450,6 +5450,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@procore-oss/backstage-plugin-announcements-react@workspace:plugins/announcements-react":
+  version: 0.0.0-use.local
+  resolution: "@procore-oss/backstage-plugin-announcements-react@workspace:plugins/announcements-react"
+  dependencies:
+    "@backstage/cli": ^0.25.1
+    "@backstage/core-app-api": ^1.11.3
+    "@backstage/core-plugin-api": ^1.8.2
+    "@backstage/errors": ^1.2.3
+    "@material-ui/core": ^4.12.2
+    "@testing-library/jest-dom": ^5.10.1
+    "@testing-library/react": ^12.1.3
+    luxon: ^3.4.4
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@procore-oss/backstage-plugin-announcements@workspace:plugins/announcements":
   version: 0.0.0-use.local
   resolution: "@procore-oss/backstage-plugin-announcements@workspace:plugins/announcements"
@@ -5505,23 +5522,6 @@ __metadata:
     cross-fetch: ^4.0.0
     msw: ^1.3.2
     winston: ^3.11.0
-  languageName: unknown
-  linkType: soft
-
-"@procore-oss/plugin-announcements-react@workspace:plugins/announcements-react":
-  version: 0.0.0-use.local
-  resolution: "@procore-oss/plugin-announcements-react@workspace:plugins/announcements-react"
-  dependencies:
-    "@backstage/cli": ^0.25.1
-    "@backstage/core-app-api": ^1.11.3
-    "@backstage/core-plugin-api": ^1.8.2
-    "@backstage/errors": ^1.2.3
-    "@material-ui/core": ^4.12.2
-    "@testing-library/jest-dom": ^5.10.1
-    "@testing-library/react": ^12.1.3
-    luxon: ^3.4.4
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
because it does not follow the proper naming convention

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
