### PR TITLE
refactor: use new -react plugin exports

### DIFF
--- a/.changeset/honest-bags-visit.md
+++ b/.changeset/honest-bags-visit.md
@@ -1,0 +1,7 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Migrate to `announcementsApiRef` and `AnnouncementApi` interface from `@procore-oss/backstage-plugin-announcements-react` and mark existing exports as deprecated.
+
+Users should now import both `announcementsApiRef` and `AnnouncementApi` from `@procore-oss/backstage-plugin-announcements-react`. Existing exports will be removed in a future release.

--- a/plugins/announcements-backend/package.json
+++ b/plugins/announcements-backend/package.json
@@ -43,7 +43,7 @@
     "@backstage/plugin-permission-node": "^0.7.20",
     "@backstage/plugin-search-backend-node": "^1.2.13",
     "@backstage/plugin-search-common": "^1.2.10",
-    "@procore-oss/backstage-plugin-announcements-common": "^0.1.3",
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^",
     "@types/express": "^4.17.6",
     "cross-fetch": "^3.1.5",
     "express": "^4.17.1",

--- a/plugins/announcements/package.json
+++ b/plugins/announcements/package.json
@@ -43,7 +43,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "@procore-oss/backstage-plugin-announcements-common": "^0.1.3",
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^",
     "@procore-oss/backstage-plugin-announcements-react": "workspace:^",
     "@uiw/react-md-editor": "^4.0.3",
     "luxon": "^3.2.0",

--- a/plugins/announcements/package.json
+++ b/plugins/announcements/package.json
@@ -44,6 +44,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@procore-oss/backstage-plugin-announcements-common": "^0.1.3",
+    "@procore-oss/backstage-plugin-announcements-react": "workspace:^",
     "@uiw/react-md-editor": "^4.0.3",
     "luxon": "^3.2.0",
     "react-use": "^17.2.4"

--- a/plugins/announcements/src/api.ts
+++ b/plugins/announcements/src/api.ts
@@ -1,13 +1,17 @@
 import { DateTime } from 'luxon';
 import { WebStorage } from '@backstage/core-app-api';
 import {
-  createApiRef,
   DiscoveryApi,
   ErrorApi,
   IdentityApi,
   FetchApi,
 } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
+import {
+  CreateAnnouncementRequest,
+  CreateCategoryRequest,
+  AnnouncementsApi,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 const lastSeenKey = 'user_last_seen_date';
 
@@ -31,57 +35,20 @@ export type AnnouncementsList = {
   results: Announcement[];
 };
 
-export type CreateAnnouncementRequest = Omit<
-  Announcement,
-  'id' | 'category' | 'created_at'
-> & {
-  category?: string;
-};
-
-export type CreateCategoryRequest = {
-  title: string;
-};
-
-export interface AnnouncementsApi {
-  announcements(opts: {
-    max?: number;
-    page?: number;
-    category?: string;
-  }): Promise<AnnouncementsList>;
-  announcementByID(id: string): Promise<Announcement>;
-
-  createAnnouncement(request: CreateAnnouncementRequest): Promise<Announcement>;
-  updateAnnouncement(
-    id: string,
-    request: CreateAnnouncementRequest,
-  ): Promise<Announcement>;
-  deleteAnnouncementByID(id: string): Promise<void>;
-
-  categories(): Promise<Category[]>;
-  createCategory(request: CreateCategoryRequest): Promise<void>;
-
-  lastSeenDate(): DateTime;
-  markLastSeenDate(date: DateTime): void;
-}
-
-export const announcementsApiRef = createApiRef<AnnouncementsApi>({
-  id: 'plugin.announcements.service',
-});
-
-type Options = {
+type AnnouncementsClientOptions = {
   discoveryApi: DiscoveryApi;
   identityApi: IdentityApi;
   errorApi: ErrorApi;
   fetchApi: FetchApi;
 };
 
-export class DefaultAnnouncementsApi implements AnnouncementsApi {
+export class AnnouncementsClient implements AnnouncementsApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
   private readonly webStorage: WebStorage;
   private readonly fetchApi: FetchApi;
 
-  constructor(opts: Options) {
+  constructor(opts: AnnouncementsClientOptions) {
     this.discoveryApi = opts.discoveryApi;
     this.identityApi = opts.identityApi;
     this.webStorage = new WebStorage('announcements', opts.errorApi);

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -8,13 +8,13 @@ import {
   makeStyles,
   TextField,
 } from '@material-ui/core';
-import {
-  Announcement,
-  announcementsApiRef,
-  CreateAnnouncementRequest,
-} from '../../api';
+import { Announcement } from '../../api';
 import { Autocomplete } from '@material-ui/lab';
 import { useAsync } from 'react-use';
+import {
+  CreateAnnouncementRequest,
+  announcementsApiRef,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles(theme => ({
   formRoot: {

--- a/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -23,8 +23,9 @@ import {
 } from '@backstage/plugin-catalog-react';
 import Alert from '@material-ui/lab/Alert';
 import { Grid } from '@material-ui/core';
-import { Announcement, announcementsApiRef } from '../../api';
+import { Announcement } from '../../api';
 import { announcementViewRouteRef, rootRouteRef } from '../../routes';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const AnnouncementDetails = ({
   announcement,

--- a/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -14,12 +14,12 @@ import {
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import NewReleasesIcon from '@material-ui/icons/NewReleases';
-import { announcementsApiRef } from '../../api';
 import {
   announcementCreateRouteRef,
   announcementViewRouteRef,
   rootRouteRef,
 } from '../../routes';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles({
   newAnnouncementIcon: {

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -7,9 +7,9 @@ import {
 import { AnnouncementsPage } from './AnnouncementsPage';
 import { rootRouteRef } from '../../routes';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
-import { announcementsApiRef } from '../../api';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
 import { fireEvent } from '@testing-library/react';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const mockAnnouncements = [
   {

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -46,11 +46,12 @@ import {
   announcementViewRouteRef,
   rootRouteRef,
 } from '../../routes';
-import { Announcement, announcementsApiRef } from '../../api';
+import { Announcement } from '../../api';
 import { DeleteAnnouncementDialog } from './DeleteAnnouncementDialog';
 import { useDeleteAnnouncementDialogState } from './useDeleteAnnouncementDialogState';
 import { Pagination } from '@material-ui/lab';
 import { ContextMenu } from './ContextMenu';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles(theme => ({
   cardHeader: {

--- a/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
+++ b/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
@@ -11,8 +11,9 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { Button, makeStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
-import { announcementsApiRef, Category } from '../../api';
+import { Category } from '../../api';
 import { NewCategoryDialog } from '../NewCategoryDialog';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles(theme => ({
   container: {

--- a/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
@@ -2,13 +2,13 @@ import React, { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Page, Header, Content } from '@backstage/core-components';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import {
-  Announcement,
-  announcementsApiRef,
-  CreateAnnouncementRequest,
-} from '../../api';
+import { Announcement } from '../../api';
 import { rootRouteRef } from '../../routes';
 import { AnnouncementForm } from '../AnnouncementForm';
+import {
+  CreateAnnouncementRequest,
+  announcementsApiRef,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 type CreateAnnouncementPageProps = {
   themeId: string;

--- a/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
@@ -9,7 +9,10 @@ import {
 import { Alert } from '@material-ui/lab';
 import { AnnouncementForm } from '../AnnouncementForm';
 import { announcementEditRouteRef } from '../../routes';
-import { announcementsApiRef, CreateAnnouncementRequest } from '../../api';
+import {
+  announcementsApiRef,
+  CreateAnnouncementRequest,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 type EditAnnouncementPageProps = {
   themeId: string;

--- a/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -11,8 +11,9 @@ import {
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import Close from '@material-ui/icons/Close';
-import { Announcement, announcementsApiRef } from '../../api';
+import { Announcement } from '../../api';
 import { announcementViewRouteRef } from '../../routes';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles(theme => ({
   // showing on top, as a block

--- a/plugins/announcements/src/components/NewCategoryDialog/NewCategoryDialog.tsx
+++ b/plugins/announcements/src/components/NewCategoryDialog/NewCategoryDialog.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
 } from '@material-ui/core';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
-import { announcementsApiRef } from '../../api';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 export type NewCategoryDialogProps = {
   open: boolean;

--- a/plugins/announcements/src/index.ts
+++ b/plugins/announcements/src/index.ts
@@ -1,11 +1,17 @@
 export * from './plugin';
 
-/**
- * @deprecated import from `announcementsApiRef` from `@procore-oss/backstage-plugin-announcements-react` instead
- */
-export { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  announcementsApiRef as announcementsApiRef_,
+  AnnouncementsApi as AnnouncementsApi_,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 /**
- * @deprecated import from `AnnouncementsApi` from `@procore-oss/backstage-plugin-announcements-react` instead
+ * @deprecated Use `AnnouncementsApi` from `@procore-oss/backstage-plugin-announcements-react` instead
  */
-export { type AnnouncementsApi } from '@procore-oss/backstage-plugin-announcements-react';
+export type AnnouncementsApi = AnnouncementsApi_;
+
+/**
+ * @public
+ * @deprecated Use `announcementsApiRef` from `@procore-oss/backstage-plugin-announcements-react` instead
+ */
+export const announcementsApiRef = announcementsApiRef_;

--- a/plugins/announcements/src/index.ts
+++ b/plugins/announcements/src/index.ts
@@ -1,2 +1,7 @@
 export * from './plugin';
-export { announcementsApiRef } from './api';
+export { AnnouncementsClient } from './api';
+
+/**
+ * @deprecated Use `announcementsApiRef` from `@procore-oss/backstage-plugin-announcements-react` instead
+ */
+export { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';

--- a/plugins/announcements/src/index.ts
+++ b/plugins/announcements/src/index.ts
@@ -1,7 +1,11 @@
 export * from './plugin';
-export { AnnouncementsClient } from './api';
 
 /**
- * @deprecated Use `announcementsApiRef` from `@procore-oss/backstage-plugin-announcements-react` instead
+ * @deprecated import from `announcementsApiRef` from `@procore-oss/backstage-plugin-announcements-react` instead
  */
 export { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+
+/**
+ * @deprecated import from `AnnouncementsApi` from `@procore-oss/backstage-plugin-announcements-react` instead
+ */
+export { type AnnouncementsApi } from '@procore-oss/backstage-plugin-announcements-react';

--- a/plugins/announcements/src/plugin.ts
+++ b/plugins/announcements/src/plugin.ts
@@ -12,9 +12,10 @@ import {
   createSearchResultListItemExtension,
   SearchResultListItemExtensionProps,
 } from '@backstage/plugin-search-react';
-import { announcementsApiRef, DefaultAnnouncementsApi } from './api';
+import { AnnouncementsClient } from './api';
 import { AnnouncementSearchResultProps } from './components/AnnouncementSearchResultListItem';
 import { rootRouteRef } from './routes';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 export const announcementsPlugin = createPlugin({
   id: 'announcements',
@@ -31,7 +32,7 @@ export const announcementsPlugin = createPlugin({
         fetchApi: fetchApiRef,
       },
       factory: ({ discoveryApi, identityApi, errorApi, fetchApi }) => {
-        return new DefaultAnnouncementsApi({
+        return new AnnouncementsClient({
           discoveryApi: discoveryApi,
           identityApi: identityApi,
           errorApi: errorApi,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5421,7 +5421,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": ^1.2.13
     "@backstage/plugin-search-common": ^1.2.10
     "@backstage/test-utils": ^1.4.7
-    "@procore-oss/backstage-plugin-announcements-common": ^0.1.3
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.15
     "@types/uuid": ^8.3.4
@@ -5441,7 +5441,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@procore-oss/backstage-plugin-announcements-common@^0.1.3, @procore-oss/backstage-plugin-announcements-common@workspace:plugins/announcements-common":
+"@procore-oss/backstage-plugin-announcements-common@workspace:^, @procore-oss/backstage-plugin-announcements-common@workspace:plugins/announcements-common":
   version: 0.0.0-use.local
   resolution: "@procore-oss/backstage-plugin-announcements-common@workspace:plugins/announcements-common"
   dependencies:
@@ -5487,7 +5487,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.57
-    "@procore-oss/backstage-plugin-announcements-common": ^0.1.3
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^"
     "@procore-oss/backstage-plugin-announcements-react": "workspace:^"
     "@testing-library/jest-dom": ^6.3.0
     "@testing-library/react": ^14.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5450,7 +5450,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@procore-oss/backstage-plugin-announcements-react@workspace:plugins/announcements-react":
+"@procore-oss/backstage-plugin-announcements-react@workspace:^, @procore-oss/backstage-plugin-announcements-react@workspace:plugins/announcements-react":
   version: 0.0.0-use.local
   resolution: "@procore-oss/backstage-plugin-announcements-react@workspace:plugins/announcements-react"
   dependencies:
@@ -5488,6 +5488,7 @@ __metadata:
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.57
     "@procore-oss/backstage-plugin-announcements-common": ^0.1.3
+    "@procore-oss/backstage-plugin-announcements-react": "workspace:^"
     "@testing-library/jest-dom": ^6.3.0
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.5.1


### PR DESCRIPTION
Details:

1. Use the new `react` plugin imports where possible
2. Re-export these imports and mark deprecated for backwards compatibility. 

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
