### PR TITLE
refactor: move reusable types to common package

### DIFF
--- a/.changeset/empty-buckets-repair.md
+++ b/.changeset/empty-buckets-repair.md
@@ -1,0 +1,9 @@
+---
+'@procore-oss/backstage-plugin-search-backend-module-announcements': patch
+'@procore-oss/backstage-plugin-announcements-backend': patch
+'@procore-oss/backstage-plugin-announcements-common': patch
+'@procore-oss/backstage-plugin-announcements-react': patch
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Consolidate duplicated types into the common package.

--- a/plugins/announcements-backend/src/api/api.ts
+++ b/plugins/announcements-backend/src/api/api.ts
@@ -1,15 +1,7 @@
 import crossFetch from 'cross-fetch';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
-
-export type Announcement = {
-  id: string;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
-  created_at: string;
-};
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 export type AnnouncementsList = {
   count: number;

--- a/plugins/announcements-backend/src/api/api.ts
+++ b/plugins/announcements-backend/src/api/api.ts
@@ -1,12 +1,10 @@
 import crossFetch from 'cross-fetch';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
-import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
-
-export type AnnouncementsList = {
-  count: number;
-  results: Announcement[];
-};
+import {
+  Announcement,
+  AnnouncementsList,
+} from '@procore-oss/backstage-plugin-announcements-common';
 
 export class AnnouncementsClient {
   private readonly discoveryApi: DiscoveryApi;

--- a/plugins/announcements-backend/src/api/index.ts
+++ b/plugins/announcements-backend/src/api/index.ts
@@ -1,1 +1,1 @@
-export { AnnouncementsClient, type Announcement } from './api';
+export { AnnouncementsClient } from './api';

--- a/plugins/announcements-backend/src/index.ts
+++ b/plugins/announcements-backend/src/index.ts
@@ -1,5 +1,5 @@
 export * from './service/router';
-export { AnnouncementsClient, type Announcement } from './api';
+export { AnnouncementsClient } from './api';
 export { announcementsPlugin as default } from './plugin';
 export { AnnouncementCollatorFactory } from './search';
 export { buildAnnouncementsContext } from './service/announcementsContextBuilder';

--- a/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
+++ b/plugins/announcements-backend/src/search/AnnouncementCollatorFactory.ts
@@ -3,7 +3,8 @@ import { Logger } from 'winston';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { IndexableDocument } from '@backstage/plugin-search-common';
-import { Announcement, AnnouncementsClient } from '../api';
+import { AnnouncementsClient } from '../api';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 type IndexableAnnouncementDocument = IndexableDocument & {
   excerpt: string;

--- a/plugins/announcements-backend/src/service/model.ts
+++ b/plugins/announcements-backend/src/service/model.ts
@@ -1,3 +1,4 @@
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 import { DateTime } from 'luxon';
 
 export type Announcement = {
@@ -8,9 +9,4 @@ export type Announcement = {
   excerpt: string;
   body: string;
   created_at: DateTime;
-};
-
-export type Category = {
-  slug: string;
-  title: string;
 };

--- a/plugins/announcements-backend/src/service/model.ts
+++ b/plugins/announcements-backend/src/service/model.ts
@@ -1,12 +1,6 @@
-import { Category } from '@procore-oss/backstage-plugin-announcements-common';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 import { DateTime } from 'luxon';
 
-export type Announcement = {
-  id: string;
-  category?: Category;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
+export type AnnouncementModel = Omit<Announcement, 'created_at'> & {
   created_at: DateTime;
 };

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -1,27 +1,20 @@
 import { Knex } from 'knex';
 import { DateTime } from 'luxon';
-import { Announcement } from '../model';
+import { AnnouncementModel } from '../model';
+import {
+  AnnouncementsFilters,
+  Announcement,
+} from '@procore-oss/backstage-plugin-announcements-common';
 
 const announcementsTable = 'announcements';
 
-type AnnouncementUpsert = {
-  id: string;
+type AnnouncementUpsert = Omit<Announcement, 'category' | 'created_at'> & {
   category?: string;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
   created_at: DateTime;
 };
 
-export type DbAnnouncement = {
-  id: string;
+export type DbAnnouncement = Omit<Announcement, 'category'> & {
   category?: string;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
-  created_at: string;
 };
 
 export type DbAnnouncementWithCategory = DbAnnouncement & {
@@ -29,15 +22,9 @@ export type DbAnnouncementWithCategory = DbAnnouncement & {
   category_title?: string;
 };
 
-type AnnouncementsFilters = {
-  max?: number;
-  offset?: number;
-  category?: string;
-};
-
-type AnnouncementsList = {
+type AnnouncementModelsList = {
   count: number;
-  results: Announcement[];
+  results: AnnouncementModel[];
 };
 
 export const timestampToDateTime = (input: Date | string): DateTime => {
@@ -71,7 +58,7 @@ const announcementUpsertToDB = (
 
 const DBToAnnouncementWithCategory = (
   announcementDb: DbAnnouncementWithCategory,
-): Announcement => {
+): AnnouncementModel => {
   return {
     id: announcementDb.id,
     category:
@@ -94,7 +81,7 @@ export class AnnouncementsDatabase {
 
   async announcements(
     request: AnnouncementsFilters,
-  ): Promise<AnnouncementsList> {
+  ): Promise<AnnouncementModelsList> {
     const countQueryBuilder = this.db<DbAnnouncement>(announcementsTable).count<
       Record<string, number>
     >('id', { as: 'total' });
@@ -135,7 +122,7 @@ export class AnnouncementsDatabase {
     };
   }
 
-  async announcementByID(id: string): Promise<Announcement | undefined> {
+  async announcementByID(id: string): Promise<AnnouncementModel | undefined> {
     const dbAnnouncement = await this.db<DbAnnouncementWithCategory>(
       announcementsTable,
     )
@@ -165,7 +152,7 @@ export class AnnouncementsDatabase {
 
   async insertAnnouncement(
     announcement: AnnouncementUpsert,
-  ): Promise<Announcement> {
+  ): Promise<AnnouncementModel> {
     await this.db<DbAnnouncement>(announcementsTable).insert(
       announcementUpsertToDB(announcement),
     );
@@ -175,7 +162,7 @@ export class AnnouncementsDatabase {
 
   async updateAnnouncement(
     announcement: AnnouncementUpsert,
-  ): Promise<Announcement> {
+  ): Promise<AnnouncementModel> {
     await this.db<DbAnnouncement>(announcementsTable)
       .where('id', announcement.id)
       .update(announcementUpsertToDB(announcement));

--- a/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.test.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { CategoriesDatabase } from './CategoriesDatabase';
 import { TestDatabases } from '@backstage/backend-test-utils';
 import { initializePersistenceContext } from './persistenceContext';
-import { Category } from '../model';
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 
 function createDatabaseManager(client: Knex, skipMigrations: boolean = false) {
   return {

--- a/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.ts
+++ b/plugins/announcements-backend/src/service/persistence/CategoriesDatabase.ts
@@ -1,5 +1,5 @@
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 import { Knex } from 'knex';
-import { Category } from '../model';
 
 const categoriesTable = 'categories';
 

--- a/plugins/announcements-backend/src/service/router.test.ts
+++ b/plugins/announcements-backend/src/service/router.test.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import { DateTime } from 'luxon';
 import request from 'supertest';
 import { AnnouncementsContext } from './announcementsContextBuilder';
-import { Announcement } from './model';
+import { AnnouncementModel } from './model';
 import { AnnouncementsDatabase } from './persistence/AnnouncementsDatabase';
 import { PersistenceContext } from './persistence/persistenceContext';
 import { createRouter } from './router';
@@ -72,7 +72,7 @@ describe('createRouter', () => {
           publisher: 'user:default/name',
           created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         },
-      ] as Announcement[]);
+      ] as AnnouncementModel[]);
 
       const response = await request(app).get('/announcements');
 

--- a/plugins/announcements-common/src/index.ts
+++ b/plugins/announcements-common/src/index.ts
@@ -1,1 +1,2 @@
 export * from './permissions';
+export * from './types';

--- a/plugins/announcements-common/src/types.ts
+++ b/plugins/announcements-common/src/types.ts
@@ -1,0 +1,19 @@
+export type Category = {
+  slug: string;
+  title: string;
+};
+
+export type Announcement = {
+  id: string;
+  category?: Category;
+  publisher: string;
+  title: string;
+  excerpt: string;
+  body: string;
+  created_at: string;
+};
+
+export type AnnouncementsList = {
+  count: number;
+  results: Announcement[];
+};

--- a/plugins/announcements-common/src/types.ts
+++ b/plugins/announcements-common/src/types.ts
@@ -17,3 +17,9 @@ export type AnnouncementsList = {
   count: number;
   results: Announcement[];
 };
+
+export type AnnouncementsFilters = {
+  max?: number;
+  offset?: number;
+  category?: string;
+};

--- a/plugins/announcements-react/package.json
+++ b/plugins/announcements-react/package.json
@@ -28,6 +28,7 @@
     "@backstage/core-plugin-api": "^1.8.2",
     "@backstage/errors": "^1.2.3",
     "@material-ui/core": "^4.12.2",
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^",
     "luxon": "^3.4.4"
   },
   "peerDependencies": {

--- a/plugins/announcements-react/src/apis/AnnouncementsApi.ts
+++ b/plugins/announcements-react/src/apis/AnnouncementsApi.ts
@@ -1,12 +1,11 @@
 import { DateTime } from 'luxon';
 import { createApiRef } from '@backstage/core-plugin-api';
+import { CreateAnnouncementRequest, CreateCategoryRequest } from './types';
 import {
-  AnnouncementsList,
   Announcement,
-  CreateAnnouncementRequest,
+  AnnouncementsList,
   Category,
-  CreateCategoryRequest,
-} from './types';
+} from '@procore-oss/backstage-plugin-announcements-common';
 
 export const announcementsApiRef = createApiRef<AnnouncementsApi>({
   id: 'plugin.announcements.service',

--- a/plugins/announcements-react/src/apis/types.ts
+++ b/plugins/announcements-react/src/apis/types.ts
@@ -1,22 +1,4 @@
-export type Category = {
-  slug: string;
-  title: string;
-};
-
-export type Announcement = {
-  id: string;
-  category?: Category;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
-  created_at: string;
-};
-
-export type AnnouncementsList = {
-  count: number;
-  results: Announcement[];
-};
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 export type CreateAnnouncementRequest = Omit<
   Announcement,

--- a/plugins/announcements/src/api.ts
+++ b/plugins/announcements/src/api.ts
@@ -12,28 +12,13 @@ import {
   CreateCategoryRequest,
   AnnouncementsApi,
 } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  Announcement,
+  AnnouncementsList,
+  Category,
+} from '@procore-oss/backstage-plugin-announcements-common';
 
 const lastSeenKey = 'user_last_seen_date';
-
-export type Category = {
-  slug: string;
-  title: string;
-};
-
-export type Announcement = {
-  id: string;
-  category?: Category;
-  publisher: string;
-  title: string;
-  excerpt: string;
-  body: string;
-  created_at: string;
-};
-
-export type AnnouncementsList = {
-  count: number;
-  results: Announcement[];
-};
 
 type AnnouncementsClientOptions = {
   discoveryApi: DiscoveryApi;

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -8,13 +8,13 @@ import {
   makeStyles,
   TextField,
 } from '@material-ui/core';
-import { Announcement } from '../../api';
 import { Autocomplete } from '@material-ui/lab';
 import { useAsync } from 'react-use';
 import {
   CreateAnnouncementRequest,
   announcementsApiRef,
 } from '@procore-oss/backstage-plugin-announcements-react';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({
   formRoot: {

--- a/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -23,9 +23,9 @@ import {
 } from '@backstage/plugin-catalog-react';
 import Alert from '@material-ui/lab/Alert';
 import { Grid } from '@material-ui/core';
-import { Announcement } from '../../api';
 import { announcementViewRouteRef, rootRouteRef } from '../../routes';
 import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 const AnnouncementDetails = ({
   announcement,

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -6,6 +6,7 @@ import {
   announcementCreatePermission,
   announcementUpdatePermission,
   announcementDeletePermission,
+  Announcement,
 } from '@procore-oss/backstage-plugin-announcements-common';
 import { DateTime } from 'luxon';
 import {
@@ -46,7 +47,6 @@ import {
   announcementViewRouteRef,
   rootRouteRef,
 } from '../../routes';
-import { Announcement } from '../../api';
 import { DeleteAnnouncementDialog } from './DeleteAnnouncementDialog';
 import { useDeleteAnnouncementDialogState } from './useDeleteAnnouncementDialogState';
 import { Pagination } from '@material-ui/lab';

--- a/plugins/announcements/src/components/AnnouncementsPage/useDeleteAnnouncementDialogState.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/useDeleteAnnouncementDialogState.tsx
@@ -1,5 +1,5 @@
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 import { useCallback, useState } from 'react';
-import { Announcement } from '../../api';
 
 export type DeleteAnnouncementDialogState = {
   open: (a: Announcement) => void;

--- a/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
+++ b/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
@@ -11,9 +11,9 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { Button, makeStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
-import { Category } from '../../api';
 import { NewCategoryDialog } from '../NewCategoryDialog';
 import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({
   container: {

--- a/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
@@ -2,13 +2,13 @@ import React, { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Page, Header, Content } from '@backstage/core-components';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import { Announcement } from '../../api';
 import { rootRouteRef } from '../../routes';
 import { AnnouncementForm } from '../AnnouncementForm';
 import {
   CreateAnnouncementRequest,
   announcementsApiRef,
 } from '@procore-oss/backstage-plugin-announcements-react';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 type CreateAnnouncementPageProps = {
   themeId: string;

--- a/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -11,9 +11,9 @@ import {
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import Close from '@material-ui/icons/Close';
-import { Announcement } from '../../api';
 import { announcementViewRouteRef } from '../../routes';
 import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({
   // showing on top, as a block

--- a/plugins/search-backend-module-announcements/package.json
+++ b/plugins/search-backend-module-announcements/package.json
@@ -31,6 +31,7 @@
     "@backstage/plugin-search-backend-node": "^1.2.13",
     "@backstage/plugin-search-common": "^1.2.10",
     "@procore-oss/backstage-plugin-announcements-backend": "workspace:^",
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^",
     "cross-fetch": "^4.0.0",
     "winston": "^3.11.0"
   },

--- a/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.ts
+++ b/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.ts
@@ -5,10 +5,8 @@ import {
   DocumentCollatorFactory,
   IndexableDocument,
 } from '@backstage/plugin-search-common';
-import {
-  Announcement,
-  AnnouncementsClient,
-} from '@procore-oss/backstage-plugin-announcements-backend';
+import { AnnouncementsClient } from '@procore-oss/backstage-plugin-announcements-backend';
+import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 type IndexableAnnouncementDocument = IndexableDocument & {
   excerpt: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5521,6 +5521,7 @@ __metadata:
     "@backstage/plugin-search-common": ^1.2.10
     "@backstage/test-utils": ^1.4.7
     "@procore-oss/backstage-plugin-announcements-backend": "workspace:^"
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^"
     cross-fetch: ^4.0.0
     msw: ^1.3.2
     winston: ^3.11.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,6 +5459,7 @@ __metadata:
     "@backstage/core-plugin-api": ^1.8.2
     "@backstage/errors": ^1.2.3
     "@material-ui/core": ^4.12.2
+    "@procore-oss/backstage-plugin-announcements-common": "workspace:^"
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
     luxon: ^3.4.4


### PR DESCRIPTION
There are many areas where types are duplicated. Migrating them to a common package follows the Backstage architecture and reduces duplication.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
