### PR TITLE
fix: release yarn workspaces properly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn version
-          publish: yarn release
+          publish: yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`yarn release` fails because it executes `yarn changset publish` which does not work with `yarn workspaces`. This PR updates our release workflow to use the yarn workspace publish commands rather than changesets.

Pending issue: https://github.com/changesets/changesets/pull/674
Backstage is doing similar [here](https://github.com/backstage/backstage/blob/7882ea60d3a82ce9247931822031d795dc6e0e20/.github/workflows/deploy_packages.yml#L180).

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
