### PR TITLE
Adding RouterProps that would allow for filtering by category

### DIFF
--- a/.changeset/shy-moose-flow.md
+++ b/.changeset/shy-moose-flow.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Added `category` to Router props to allow filtering on individual routes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,3 +31,17 @@ Example
 ```tsx
 <AnnouncementsPage cardOptions={{ titleLength: 10 }} />
 ```
+
+### Overriding the AnnouncementsPage
+
+It is possible to specify the Announcements within a specific category rendered on the `AnnouncementsPage`. You can do this by passing a `category` prop to the `AnnouncementsPage` component. The `AnnouncementsPage` prop accepts an value such as:
+
+```ts
+category = 'conferences';
+```
+
+Example
+
+```tsx
+<AnnouncementsPage category="conferences" />
+```

--- a/plugins/announcements/src/components/Router.tsx
+++ b/plugins/announcements/src/components/Router.tsx
@@ -21,6 +21,7 @@ type RouterProps = {
   themeId?: string;
   title?: string;
   subtitle?: string;
+  category?: string;
   cardOptions?: {
     titleLength: number | undefined;
   };


### PR DESCRIPTION
Adds a router prop that will allow us to filter on categories.  
#294 

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

