### PR TITLE
Adding the ability to adjust the button on AnnouncementsPage using props

### DIFF
--- a/.changeset/fifty-dodos-knock.md
+++ b/.changeset/fifty-dodos-knock.md
@@ -2,4 +2,4 @@
 '@procore-oss/backstage-plugin-announcements': patch
 ---
 
-Added a property for AnnouncementsPage named `createNoun` which will adjust what is shown in the "New announcement" LinkButton. eg. `createNoun = Pizza` will update LinkButton to "New Pizza"
+Added a property for AnnouncementsPage named `buttonOptions.name` to `AnnouncementCreateButtonProps` which will adjust what is shown in the "New announcement" LinkButton. eg. `buttonOptions.name = Pizza` will update LinkButton to "New Pizza"

--- a/.changeset/fifty-dodos-knock.md
+++ b/.changeset/fifty-dodos-knock.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Added a property for AnnouncementsPage named `createNoun` which will adjust what is shown in the "New announcement" LinkButton. eg. `createNoun = Pizza` will update LinkButton to "New Pizza"

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,3 +45,13 @@ Example
 ```tsx
 <AnnouncementsPage category="conferences" />
 ```
+
+### Overriding the AnnouncementCreateButton
+
+It is possible to specify the text for the "New announcement" button rendered on the `AnnouncementsPage`. You can do this by passing a `buttonOptions` prop to the `AnnouncementsPage` component. The `buttonOptions` prop accepts an object with the following properties:
+
+```ts
+{
+  name: string; // defaults to 'announcement'
+}
+```

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -92,6 +92,7 @@ describe('AnnouncementsPage', () => {
           <AnnouncementsPage
             themeId="home"
             title="Announcements"
+            createNoun="customNoun"
             cardOptions={{ titleLength: 13 }}
           />
         </TestApiProvider>,
@@ -105,6 +106,7 @@ describe('AnnouncementsPage', () => {
       expect(rendered.getByText('Announcements')).toBeInTheDocument();
       expect(rendered.queryByText('announcement-title')).toBeNull();
       expect(rendered.getByText('announcement-...')).toBeInTheDocument();
+      expect(rendered.getByText('customNoun')).toBeInTheDocument();
 
       fireEvent.mouseOver(rendered.getByText('announcement-...'));
       expect(

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -92,7 +92,7 @@ describe('AnnouncementsPage', () => {
           <AnnouncementsPage
             themeId="home"
             title="Announcements"
-            createNoun="customNoun"
+            buttonOptions={{ name: "customNoun" }}
             cardOptions={{ titleLength: 13 }}
           />
         </TestApiProvider>,

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -103,10 +103,11 @@ describe('AnnouncementsPage', () => {
           },
         },
       );
+
       expect(rendered.getByText('Announcements')).toBeInTheDocument();
       expect(rendered.queryByText('announcement-title')).toBeNull();
       expect(rendered.getByText('announcement-...')).toBeInTheDocument();
-      expect(rendered.getByText('customNoun')).toBeInTheDocument();
+      expect(rendered.getByText('New customNoun')).toBeInTheDocument();
 
       fireEvent.mouseOver(rendered.getByText('announcement-...'));
       expect(

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -294,6 +294,7 @@ type AnnouncementsPageProps = {
   subtitle?: ReactNode;
   maxPerPage?: number;
   category?: string;
+  createNoun?: string;
   cardOptions?: AnnouncementCardProps;
 };
 
@@ -319,7 +320,9 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
               color="primary"
               variant="contained"
             >
-              New announcement
+              {props.createNoun
+                ? `New ${props.createNoun}`
+                : 'New announcement'}
             </LinkButton>
           )}
         </ContentHeader>

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -325,7 +325,7 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
               variant="contained"
             >
               {props.buttonOptions
-                ? `New ${buttonOptions.name}`
+                ? `New ${props.buttonOptions.name}`
                 : 'New announcement'}
             </LinkButton>
           )}

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -288,13 +288,17 @@ type AnnouncementCardProps = {
   titleLength?: number;
 };
 
+type AnnouncementCreateButtonProps = {
+  name?: string
+};
+
 type AnnouncementsPageProps = {
   themeId: string;
   title: string;
   subtitle?: ReactNode;
   maxPerPage?: number;
   category?: string;
-  createNoun?: string;
+  buttonOptions?: AnnouncementCreateButtonProps
   cardOptions?: AnnouncementCardProps;
 };
 
@@ -320,8 +324,8 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
               color="primary"
               variant="contained"
             >
-              {props.createNoun
-                ? `New ${props.createNoun}`
+              {props.buttonOptions
+                ? `New ${buttonOptions.name}`
                 : 'New announcement'}
             </LinkButton>
           )}


### PR DESCRIPTION
This addresses #298 

Checklist:

* [X] I have updated the necessary documentation
* [X] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [X] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
