### PR TITLE
fix: separate commands into two steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,12 @@ jobs:
           version: yarn version
           publish:
             yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
-            yarn changeset tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install Dependencies
+        run: yarn changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Attempting to publish each package and ensure releases are updated in GitHub.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
