### PR TITLE
ci: yarn command is not authenticating properly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Enable non-immutable yarn installs
         run: yarn config set -H enableImmutableInstalls false
 
+      - name: Authenticate yarn with NPM
+        run: yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
Yarn is not authing correctly to publish packages. Merging this _may_ fix things. 
