### PR TITLE
Category creation should have permissions

### DIFF
--- a/.changeset/calm-hairs-kneel.md
+++ b/.changeset/calm-hairs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Adding permission checks to category creation.

--- a/plugins/announcements-backend/src/service/router.ts
+++ b/plugins/announcements-backend/src/service/router.ts
@@ -178,6 +178,10 @@ export async function createRouter(
   router.post(
     '/categories',
     async (req: Request<{}, {}, CategoryRequest, {}>, res) => {
+      if (!(await isRequestAuthorized(req, announcementCreatePermission))) {
+        throw new NotAllowedError('Unauthorized');
+      }
+
       const category = {
         ...req.body,
         ...{


### PR DESCRIPTION
This was raised by @JD-Gonz in #310 and I verified this as well - users who have no permissions are able to add categories.  
I feel like announcement creation could also align with category creation, so maybe not a lot of value in making permissions too granular and adding .category.create/update/delete at this point.  

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green


