### PR TITLE
Added buttonOptions to router props so that this can be overridden

### DIFF
--- a/.changeset/big-poems-marry.md
+++ b/.changeset/big-poems-marry.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Added buttonOptions to router props so that this can be overridden

--- a/plugins/announcements/src/components/Router.tsx
+++ b/plugins/announcements/src/components/Router.tsx
@@ -25,6 +25,9 @@ type RouterProps = {
   cardOptions?: {
     titleLength: number | undefined;
   };
+  buttonOptions?: {
+    name: string | undefined;
+  };
 };
 
 export const Router = (props: RouterProps) => {


### PR DESCRIPTION
This should resolve the issue I was seeing with the values not being available in the latest version.  
Relates to #299 

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
