### PR TITLE
Added property variant to AnnouncementsCard

### DIFF
--- a/.changeset/sour-turkeys-wonder.md
+++ b/.changeset/sour-turkeys-wonder.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Added property `variant` to `AnnouncementsCard`

--- a/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { useAsync } from 'react-use';
 import { DateTime } from 'luxon';
 import { usePermission } from '@backstage/plugin-permission-react';
-import { InfoCard, Link, Progress } from '@backstage/core-components';
+import {
+  InfoCard,
+  InfoCardVariants,
+  Link,
+  Progress,
+} from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { announcementEntityPermissions } from '@procore-oss/backstage-plugin-announcements-common';
 import {
@@ -31,12 +36,14 @@ type AnnouncementsCardOpts = {
   title?: string;
   max?: number;
   category?: string;
+  variant?: InfoCardVariants;
 };
 
 export const AnnouncementsCard = ({
   title,
   max,
   category,
+  variant = 'gridItem',
 }: AnnouncementsCardOpts) => {
   const classes = useStyles();
   const announcementsApi = useApi(announcementsApiRef);
@@ -74,7 +81,7 @@ export const AnnouncementsCard = ({
   return (
     <InfoCard
       title={title || 'Announcements'}
-      variant="gridItem"
+      variant={variant}
       deepLink={deepLink}
     >
       <List dense>


### PR DESCRIPTION
This allows you to override the default value `gridItem`, which is useful when using the card on a homepage for example. (otherwise it adds a margin to the bottom of the card, making the card inconsistent in size compared to the others)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green
