### PR TITLE
feat: dynamically create category from new announcement form

### DIFF
--- a/.changeset/funny-bugs-clean.md
+++ b/.changeset/funny-bugs-clean.md
@@ -1,8 +1,0 @@
----
-'@procore-oss/backstage-plugin-announcements-react': patch
-'@procore-oss/backstage-plugin-announcements': patch
----
-
-Added two new hooks (useAnnouncements and useCategories) to refactor out some repetive calls to the announcementsApi on the frontend.
-
-While not the primary objective, these will be exported from '@procore-oss/backstage-plugin-announcements-react' so adopters _could_ retrieve announcements and display them as they see fit.

--- a/.changeset/silly-owls-sneeze.md
+++ b/.changeset/silly-owls-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Adds the ability to create new categories dynamically from the new announcement form

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -2,19 +2,10 @@ import React from 'react';
 import MDEditor from '@uiw/react-md-editor';
 import { InfoCard } from '@backstage/core-components';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  Button,
-  CircularProgress,
-  makeStyles,
-  TextField,
-} from '@material-ui/core';
-import { Autocomplete } from '@material-ui/lab';
-import { useAsync } from 'react-use';
-import {
-  CreateAnnouncementRequest,
-  announcementsApiRef,
-} from '@procore-oss/backstage-plugin-announcements-react';
+import { Button, makeStyles, TextField } from '@material-ui/core';
+import { CreateAnnouncementRequest } from '@procore-oss/backstage-plugin-announcements-react';
 import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
+import CategoryInput from './CategoryInput';
 
 const useStyles = makeStyles(theme => ({
   formRoot: {
@@ -40,12 +31,6 @@ export const AnnouncementForm = ({
     category: initialData.category?.slug,
   });
   const [loading, setLoading] = React.useState(false);
-
-  const announcementsApi = useApi(announcementsApiRef);
-  const { value: categories, loading: categoriesLoading } = useAsync(
-    () => announcementsApi.categories(),
-    [announcementsApi],
-  );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setForm({
@@ -85,36 +70,10 @@ export const AnnouncementForm = ({
           fullWidth
           required
         />
-        <Autocomplete
-          fullWidth
-          getOptionSelected={(option, value) => option.slug === value.slug}
-          getOptionLabel={option => option.title}
-          value={initialData.category}
-          onChange={(_event, newInputValue) =>
-            setForm({ ...form, category: newInputValue?.slug })
-          }
-          options={categories || []}
-          loading={categoriesLoading}
-          renderInput={params => (
-            <TextField
-              {...params}
-              id="category"
-              label="Category"
-              variant="outlined"
-              fullWidth
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>
-                    {categoriesLoading ? (
-                      <CircularProgress color="inherit" size={20} />
-                    ) : null}
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-            />
-          )}
+        <CategoryInput
+          setForm={setForm}
+          form={form}
+          initialValue={initialData.category?.title ?? ''}
         />
         <TextField
           id="excerpt"

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -2,17 +2,8 @@ import React from 'react';
 import MDEditor from '@uiw/react-md-editor';
 import { InfoCard } from '@backstage/core-components';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  Button,
-  CircularProgress,
-  makeStyles,
-  TextField,
-} from '@material-ui/core';
-import { Autocomplete } from '@material-ui/lab';
-import {
-  CreateAnnouncementRequest,
-  useCategories,
-} from '@procore-oss/backstage-plugin-announcements-react';
+import { Button, makeStyles, TextField } from '@material-ui/core';
+import { CreateAnnouncementRequest } from '@procore-oss/backstage-plugin-announcements-react';
 import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 import CategoryInput from './CategoryInput';
 
@@ -40,8 +31,6 @@ export const AnnouncementForm = ({
     category: initialData.category?.slug,
   });
   const [loading, setLoading] = React.useState(false);
-
-  // const { categories, loading: categoriesLoading } = useCategories();
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setForm({

--- a/plugins/announcements/src/components/AnnouncementForm/CategoryInput.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/CategoryInput.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestApiProvider } from '@backstage/test-utils';
+
+import CategoryInput from './CategoryInput';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import { renderInTestApp } from '@backstage/test-utils';
+
+const categories = [
+  { title: 'Hello', slug: 'hello' },
+  { title: 'World', slug: 'world' },
+];
+
+jest.mock('@procore-oss/backstage-plugin-announcements-react', () => ({
+  ...jest.requireActual('@procore-oss/backstage-plugin-announcements-react'),
+  useCategories: () => {
+    return {
+      categories,
+      loading: false,
+      error: undefined,
+      retry: jest.fn(),
+    };
+  },
+}));
+
+describe('CategoryInput', () => {
+  const mockSetForm: (
+    value: React.SetStateAction<{
+      category: string | undefined;
+      id: string;
+      publisher: string;
+      title: string;
+      excerpt: string;
+      body: string;
+      created_at: string;
+    }>,
+  ) => void = jest.fn();
+
+  const mockForm = {
+    category: 'category',
+    id: 'id',
+    publisher: 'publisher',
+    title: 'title',
+    excerpt: 'excerpt',
+    body: 'body',
+    created_at: 'created_at',
+  };
+
+  const announcementsApiMock = { categories: jest.fn() };
+
+  const render = async () => {
+    await renderInTestApp(
+      <TestApiProvider apis={[[announcementsApiRef, announcementsApiMock]]}>
+        <CategoryInput setForm={mockSetForm} form={mockForm} initialValue="" />
+      </TestApiProvider>,
+    );
+  };
+
+  it('should render the CategoryInput component', async () => {
+    await render();
+
+    await waitFor(() => {
+      screen.getByRole('combobox');
+    });
+
+    const autocomplete = screen.getByRole('combobox');
+
+    expect(autocomplete).toBeInTheDocument();
+    expect(screen.getByLabelText('Category')).toBeInTheDocument();
+
+    await userEvent.click(autocomplete);
+
+    const expectedOption1 = screen.getByRole('option', {
+      name: categories[0].title,
+    });
+
+    const expectedOption2 = screen.getByRole('option', {
+      name: categories[1].title,
+    });
+
+    expect(expectedOption1).toBeInTheDocument();
+    expect(expectedOption2).toBeInTheDocument();
+
+    expect(expectedOption1.textContent).toEqual('Hello');
+    expect(expectedOption2.textContent).toEqual('World');
+  });
+
+  it('should set category when a category is selected', async () => {
+    await render();
+
+    await waitFor(() => {
+      screen.getByRole('combobox');
+    });
+
+    const autocomplete = screen.getByRole('combobox');
+
+    await userEvent.click(autocomplete);
+
+    const expectedOption = screen.getByRole('option', {
+      name: categories[0].title,
+    });
+
+    await userEvent.click(expectedOption);
+
+    expect(mockSetForm).toHaveBeenCalledWith({
+      ...mockForm,
+      category: 'Hello',
+    });
+  });
+
+  it('should set category when a new category is created', async () => {
+    await render();
+
+    await waitFor(() => {
+      screen.getByRole('combobox');
+    });
+
+    const autocomplete = screen.getByRole('combobox');
+    const newCategoryMock = 'New Category';
+
+    await userEvent.click(autocomplete);
+    await userEvent.type(autocomplete, 'New Category');
+    await userEvent.click(screen.getByText(`Create "${newCategoryMock}"`));
+
+    expect(mockSetForm).toHaveBeenCalledWith({
+      ...mockForm,
+      category: 'New Category',
+    });
+  });
+});

--- a/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
+import { useApi } from '@backstage/core-plugin-api';
+import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import { useAsync } from 'react-use';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+type CategoryInputProps = {
+  setForm: (
+    value: React.SetStateAction<{
+      category: string | undefined;
+      id: string;
+      publisher: string;
+      title: string;
+      excerpt: string;
+      body: string;
+      created_at: string;
+    }>,
+  ) => void;
+  form: {
+    category: string | undefined;
+    id: string;
+    publisher: string;
+    title: string;
+    excerpt: string;
+    body: string;
+    created_at: string;
+  };
+  initialValue: string;
+};
+
+const filter = createFilterOptions<Category>();
+
+export default function CategoryInput({
+  setForm,
+  form,
+  initialValue,
+}: CategoryInputProps) {
+  const announcementsApi = useApi(announcementsApiRef);
+
+  const { value: categories, loading: categoriesLoading } = useAsync(
+    () => announcementsApi.categories(),
+    [announcementsApi],
+  );
+
+  return (
+    <Autocomplete
+      fullWidth
+      value={initialValue ?? ''}
+      onChange={async (_, newValue) => {
+        if (!newValue) {
+          setForm({ ...form, category: undefined });
+          return;
+        }
+
+        const newCategory = (
+          typeof newValue === 'string' ? newValue : newValue.title
+        )
+          .replace('Create "', '')
+          .replace('"', '');
+
+        setForm({ ...form, category: newCategory });
+      }}
+      filterOptions={(options, params) => {
+        const filtered = filter(options, params);
+        const { inputValue } = params;
+
+        /*
+          Suggest the creation of a new category. This adds the new value to the list of options
+          and creates the new category when the form is submitted.
+        */
+        const isExisting = options.some(option => inputValue === option.title);
+        if (inputValue !== '' && !isExisting) {
+          filtered.push({
+            title: `Create "${inputValue}"`,
+            slug: inputValue.toLowerCase(),
+          });
+        }
+
+        return filtered;
+      }}
+      selectOnFocus
+      handleHomeEndKeys
+      loading={categoriesLoading}
+      id="category-input-field"
+      options={categories || []}
+      getOptionLabel={option => {
+        // Value selected with enter, right from the input
+        if (typeof option === 'string') {
+          return option;
+        }
+
+        return option.slug;
+      }}
+      renderOption={(props, option) => <li {...props}>{option.title}</li>}
+      freeSolo
+      renderInput={params => (
+        <TextField
+          {...params}
+          id="category"
+          label="Category"
+          variant="outlined"
+          fullWidth
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {categoriesLoading ? (
+                  <CircularProgress color="inherit" size={20} />
+                ) : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
@@ -64,7 +64,9 @@ export default function CategoryInput({
           Suggest the creation of a new category. This adds the new value to the list of options
           and creates the new category when the form is submitted.
         */
-        const isExisting = options.some(option => inputValue === option.title);
+        const isExisting = options.some(
+          option => inputValue.toLowerCase() === option.title.toLowerCase(),
+        );
         if (inputValue !== '' && !isExisting) {
           filtered.push({
             title: `Create "${inputValue}"`,

--- a/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
@@ -58,8 +58,8 @@ export default function CategoryInput({
         const newCategory = (
           typeof newValue === 'string' ? newValue : newValue.title
         )
-          .replace('Create "', '')
-          .replace('"', '');
+          .replace('Create ', '')
+          .replaceAll('"', '');
 
         setForm({ ...form, category: newCategory });
       }}

--- a/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
@@ -8,7 +8,10 @@ import {
   CreateAnnouncementRequest,
   announcementsApiRef,
 } from '@procore-oss/backstage-plugin-announcements-react';
-import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
+import {
+  Announcement,
+  Category,
+} from '@procore-oss/backstage-plugin-announcements-common';
 
 type CreateAnnouncementPageProps = {
   themeId: string;
@@ -23,9 +26,26 @@ export const CreateAnnouncementPage = (props: CreateAnnouncementPageProps) => {
   const navigate = useNavigate();
 
   const onSubmit = async (request: CreateAnnouncementRequest) => {
+    const { category } = request;
+    const categories = await announcementsApi.categories();
+    const slugs = categories.map((c: Category) => c.slug);
+    let alertMsg = 'Announcement created.';
+
     try {
-      await announcementsApi.createAnnouncement(request);
-      alertApi.post({ message: 'Announcement created.', severity: 'success' });
+      if (category && slugs.indexOf(category) === -1) {
+        alertMsg = alertMsg.replace('.', '');
+        alertMsg = `${alertMsg} with new category ${category}.`;
+
+        await announcementsApi.createCategory({
+          title: category,
+        });
+      }
+
+      await announcementsApi.createAnnouncement({
+        ...request,
+        category: request.category?.toLowerCase(),
+      });
+      alertApi.post({ message: alertMsg, severity: 'success' });
 
       navigate(rootPage());
     } catch (err) {

--- a/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx
@@ -7,6 +7,7 @@ import { AnnouncementForm } from '../AnnouncementForm';
 import {
   CreateAnnouncementRequest,
   announcementsApiRef,
+  useCategories,
 } from '@procore-oss/backstage-plugin-announcements-react';
 import {
   Announcement,
@@ -24,10 +25,11 @@ export const CreateAnnouncementPage = (props: CreateAnnouncementPageProps) => {
   const rootPage = useRouteRef(rootRouteRef);
   const alertApi = useApi(alertApiRef);
   const navigate = useNavigate();
+  const { categories } = useCategories();
 
   const onSubmit = async (request: CreateAnnouncementRequest) => {
     const { category } = request;
-    const categories = await announcementsApi.categories();
+
     const slugs = categories.map((c: Category) => c.slug);
     let alertMsg = 'Announcement created.';
 

--- a/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
+++ b/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
@@ -44,9 +44,11 @@ export const EditAnnouncementPage = (props: EditAnnouncementPageProps) => {
     content = <Progress />;
   } else if (error) {
     content = <Alert severity="error">{error.message}</Alert>;
+  } else if (!value) {
+    content = <Alert severity="error">Unable to find announcement</Alert>;
   } else {
-    title = `Edit "${value!.title}" – ${title}`;
-    content = <AnnouncementForm initialData={value!} onSubmit={onSubmit} />;
+    title = `Edit "${value.title}" – ${title}`;
+    content = <AnnouncementForm initialData={value} onSubmit={onSubmit} />;
   }
 
   return (


### PR DESCRIPTION
Closes https://github.com/procore-oss/backstage-plugin-announcements/issues/314

https://github.com/procore-oss/backstage-plugin-announcements/assets/14222009/a04a4237-f6a1-40b3-911f-f86601a3e88f

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
