### PR TITLE
feat: useAnnouncements and useCategories hooks

### DIFF
--- a/.changeset/funny-bugs-clean.md
+++ b/.changeset/funny-bugs-clean.md
@@ -1,0 +1,6 @@
+---
+'@procore-oss/backstage-plugin-announcements-react': patch
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Added two new hooks (useAnnouncements and useCategories) to refactor out some repetive calls to the announcementsApi on the frontend.

--- a/plugins/announcements-react/README.md
+++ b/plugins/announcements-react/README.md
@@ -1,3 +1,7 @@
 # @procore-oss/backstage-plugin-announcements-react
 
-Welcome to the web library package for the announcements plugin!
+This library provides reusable components for displaying announcements in a Backstage plugin.
+
+## Hooks
+
+There are multiple [hooks](./src/hooks/index.ts) you may use in your Backstage plugin to fetch and use announcements however you see fit.

--- a/plugins/announcements-react/package.json
+++ b/plugins/announcements-react/package.json
@@ -29,7 +29,8 @@
     "@backstage/errors": "^1.2.4",
     "@material-ui/core": "^4.12.2",
     "@procore-oss/backstage-plugin-announcements-common": "workspace:^",
-    "luxon": "^3.4.4"
+    "luxon": "^3.4.4",
+    "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"

--- a/plugins/announcements-react/src/hooks/index.ts
+++ b/plugins/announcements-react/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAnnouncements } from './useAnnouncements';
+export { useCategories } from './useCategories';

--- a/plugins/announcements-react/src/hooks/useAnnouncements.ts
+++ b/plugins/announcements-react/src/hooks/useAnnouncements.ts
@@ -1,0 +1,22 @@
+import { useApi } from '@backstage/core-plugin-api';
+import { announcementsApiRef } from '../apis';
+import useAsync from 'react-use/esm/useAsync';
+import {
+  Announcement,
+  AnnouncementsFilters,
+} from '@procore-oss/backstage-plugin-announcements-common';
+
+export const useAnnouncements = (
+  props: AnnouncementsFilters,
+): { announcements: Announcement[]; loading: boolean } => {
+  const api = useApi(announcementsApiRef);
+
+  const { value: announcements, loading } = useAsync(async () => {
+    return await api.announcements(props);
+  });
+
+  return {
+    announcements: announcements?.results ?? [],
+    loading,
+  };
+};

--- a/plugins/announcements-react/src/hooks/useAnnouncements.ts
+++ b/plugins/announcements-react/src/hooks/useAnnouncements.ts
@@ -8,15 +8,24 @@ import {
 
 export const useAnnouncements = (
   props: AnnouncementsFilters,
-): { announcements: Announcement[]; loading: boolean } => {
+): {
+  announcements: Announcement[];
+  loading: boolean;
+  error: Error | undefined;
+} => {
   const api = useApi(announcementsApiRef);
 
-  const { value: announcements, loading } = useAsync(async () => {
+  const {
+    value: announcements,
+    loading,
+    error,
+  } = useAsync(async () => {
     return await api.announcements(props);
   });
 
   return {
     announcements: announcements?.results ?? [],
     loading,
+    error,
   };
 };

--- a/plugins/announcements-react/src/hooks/useAnnouncements.ts
+++ b/plugins/announcements-react/src/hooks/useAnnouncements.ts
@@ -3,6 +3,7 @@ import { announcementsApiRef } from '../apis';
 import {
   Announcement,
   AnnouncementsFilters,
+  AnnouncementsList,
 } from '@procore-oss/backstage-plugin-announcements-common';
 import { useAsyncRetry } from 'react-use';
 
@@ -14,8 +15,7 @@ export const useAnnouncements = (
   props: AnnouncementsFilters,
   options?: UseAnnouncementsPropOptions,
 ): {
-  announcements: Announcement[];
-  total: number;
+  announcements: AnnouncementsList;
   loading: boolean;
   error: Error | undefined;
   retry: () => void;
@@ -32,8 +32,7 @@ export const useAnnouncements = (
   }, [api, ...(options?.dependencies ?? [])]);
 
   return {
-    announcements: announcementsList?.results ?? [],
-    total: announcementsList?.count ?? 0,
+    announcements: announcementsList ?? { count: 0, results: [] },
     loading,
     error,
     retry,

--- a/plugins/announcements-react/src/hooks/useAnnouncements.ts
+++ b/plugins/announcements-react/src/hooks/useAnnouncements.ts
@@ -1,7 +1,6 @@
 import { useApi } from '@backstage/core-plugin-api';
 import { announcementsApiRef } from '../apis';
 import {
-  Announcement,
   AnnouncementsFilters,
   AnnouncementsList,
 } from '@procore-oss/backstage-plugin-announcements-common';

--- a/plugins/announcements-react/src/hooks/useCategories.ts
+++ b/plugins/announcements-react/src/hooks/useCategories.ts
@@ -1,0 +1,20 @@
+import { useApi } from '@backstage/core-plugin-api';
+import { announcementsApiRef } from '../apis';
+import useAsync from 'react-use/esm/useAsync';
+import { Category } from '@procore-oss/backstage-plugin-announcements-common';
+
+export const useCategories = (): {
+  categories: Category[];
+  loading: boolean;
+} => {
+  const api = useApi(announcementsApiRef);
+
+  const { value: categories, loading } = useAsync(async () => {
+    return await api.categories();
+  });
+
+  return {
+    categories: categories ?? [],
+    loading,
+  };
+};

--- a/plugins/announcements-react/src/hooks/useCategories.ts
+++ b/plugins/announcements-react/src/hooks/useCategories.ts
@@ -1,20 +1,29 @@
 import { useApi } from '@backstage/core-plugin-api';
 import { announcementsApiRef } from '../apis';
-import useAsync from 'react-use/esm/useAsync';
 import { Category } from '@procore-oss/backstage-plugin-announcements-common';
+import { useAsyncRetry } from 'react-use';
 
 export const useCategories = (): {
   categories: Category[];
   loading: boolean;
+  error: Error | undefined;
+  retry: () => void;
 } => {
   const api = useApi(announcementsApiRef);
 
-  const { value: categories, loading } = useAsync(async () => {
+  const {
+    value: categories,
+    loading,
+    error,
+    retry,
+  } = useAsyncRetry(async () => {
     return await api.categories();
   });
 
   return {
     categories: categories ?? [],
     loading,
+    error,
+    retry,
   };
 };

--- a/plugins/announcements-react/src/index.ts
+++ b/plugins/announcements-react/src/index.ts
@@ -9,3 +9,4 @@
 // that are useful to other plugins or modules.
 
 export * from './apis';
+export * from './hooks';

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -13,6 +13,7 @@ import { useAsync } from 'react-use';
 import {
   CreateAnnouncementRequest,
   announcementsApiRef,
+  useCategories,
 } from '@procore-oss/backstage-plugin-announcements-react';
 import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
@@ -41,11 +42,7 @@ export const AnnouncementForm = ({
   });
   const [loading, setLoading] = React.useState(false);
 
-  const announcementsApi = useApi(announcementsApiRef);
-  const { value: categories, loading: categoriesLoading } = useAsync(
-    () => announcementsApi.categories(),
-    [announcementsApi],
-  );
+  const { categories, loading: categoriesLoading } = useCategories();
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setForm({

--- a/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -9,10 +9,8 @@ import {
   TextField,
 } from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
-import { useAsync } from 'react-use';
 import {
   CreateAnnouncementRequest,
-  announcementsApiRef,
   useCategories,
 } from '@procore-oss/backstage-plugin-announcements-react';
 import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';

--- a/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useAsync } from 'react-use';
 import { DateTime } from 'luxon';
 import { usePermission } from '@backstage/plugin-permission-react';
 import {
@@ -83,7 +82,7 @@ export const AnnouncementsCard = ({
       deepLink={deepLink}
     >
       <List dense>
-        {announcements.map(announcement => (
+        {announcements.results.map(announcement => (
           <ListItem key={announcement.id}>
             <ListItem>
               {lastSeen < DateTime.fromISO(announcement.created_at) && (
@@ -124,7 +123,7 @@ export const AnnouncementsCard = ({
             </ListItem>
           </ListItem>
         ))}
-        {announcements.length === 0 && !loadingPermission && canAdd && (
+        {announcements.count === 0 && !loadingPermission && canAdd && (
           <ListItem>
             <ListItemText>
               No announcements yet, want to{' '}

--- a/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -24,7 +24,10 @@ import {
   announcementViewRouteRef,
   rootRouteRef,
 } from '../../routes';
-import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  announcementsApiRef,
+  useAnnouncements,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles({
   newAnnouncementIcon: {
@@ -52,16 +55,11 @@ export const AnnouncementsCard = ({
   const createAnnouncementLink = useRouteRef(announcementCreateRouteRef);
   const lastSeen = announcementsApi.lastSeenDate();
 
-  const {
-    value: announcements,
-    loading,
-    error,
-  } = useAsync(async () =>
-    announcementsApi.announcements({
-      max: max || 5,
-      category,
-    }),
-  );
+  const { announcements, loading, error } = useAnnouncements({
+    max: max || 5,
+    category,
+  });
+
   const { announcementCreatePermission } = announcementEntityPermissions;
   const { loading: loadingPermission, allowed: canAdd } = usePermission({
     permission: announcementCreatePermission,
@@ -85,7 +83,7 @@ export const AnnouncementsCard = ({
       deepLink={deepLink}
     >
       <List dense>
-        {announcements?.results.map(announcement => (
+        {announcements.map(announcement => (
           <ListItem key={announcement.id}>
             <ListItem>
               {lastSeen < DateTime.fromISO(announcement.created_at) && (
@@ -126,7 +124,7 @@ export const AnnouncementsCard = ({
             </ListItem>
           </ListItem>
         ))}
-        {announcements?.count === 0 && !loadingPermission && canAdd && (
+        {announcements.length === 0 && !loadingPermission && canAdd && (
           <ListItem>
             <ListItemText>
               No announcements yet, want to{' '}

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import { useAsyncRetry } from 'react-use';
 import { useLocation } from 'react-router-dom';
 import { usePermission } from '@backstage/plugin-permission-react';
 import {
@@ -51,7 +50,10 @@ import { DeleteAnnouncementDialog } from './DeleteAnnouncementDialog';
 import { useDeleteAnnouncementDialogState } from './useDeleteAnnouncementDialogState';
 import { Pagination } from '@material-ui/lab';
 import { ContextMenu } from './ContextMenu';
-import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  announcementsApiRef,
+  useAnnouncements,
+} from '@procore-oss/backstage-plugin-announcements-react';
 
 const useStyles = makeStyles(theme => ({
   cardHeader: {
@@ -213,15 +215,18 @@ const AnnouncementsGrid = ({
   };
 
   const {
-    value: announcementsList,
+    announcements,
     loading,
     error,
     retry: refresh,
-  } = useAsyncRetry(
-    async () =>
-      announcementsApi.announcements({ max: maxPerPage, page, category }),
-    [page, maxPerPage, category],
+  } = useAnnouncements(
+    {
+      max: maxPerPage,
+      category,
+    },
+    { dependencies: [maxPerPage, page, category] },
   );
+
   const {
     isOpen: isDeleteDialogOpen,
     open: openDeleteDialog,
@@ -255,7 +260,7 @@ const AnnouncementsGrid = ({
   return (
     <>
       <ItemCardGrid>
-        {announcementsList?.results.map(announcement => (
+        {announcements.results.map(announcement => (
           <AnnouncementCard
             key={announcement.id}
             announcement={announcement}
@@ -265,10 +270,10 @@ const AnnouncementsGrid = ({
         ))}
       </ItemCardGrid>
 
-      {announcementsList && announcementsList.count !== 0 && (
+      {announcements && announcements.count !== 0 && (
         <div className={classes.pagination}>
           <Pagination
-            count={Math.ceil(announcementsList.count / maxPerPage)}
+            count={Math.ceil(announcements.count / maxPerPage)}
             page={page}
             onChange={handleChange}
           />
@@ -289,7 +294,7 @@ type AnnouncementCardProps = {
 };
 
 type AnnouncementCreateButtonProps = {
-  name?: string
+  name?: string;
 };
 
 type AnnouncementsPageProps = {
@@ -298,7 +303,7 @@ type AnnouncementsPageProps = {
   subtitle?: ReactNode;
   maxPerPage?: number;
   category?: string;
-  buttonOptions?: AnnouncementCreateButtonProps
+  buttonOptions?: AnnouncementCreateButtonProps;
   cardOptions?: AnnouncementCardProps;
 };
 

--- a/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
+++ b/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
@@ -15,6 +15,7 @@ import Stack from '@mui/material/Stack';
 import { DateTime } from 'luxon';
 import { announcementViewRouteRef } from '../../routes';
 import { useAnnouncements } from '@procore-oss/backstage-plugin-announcements-react';
+import { Progress } from '@backstage/core-components';
 
 /**
  * Props for the AnnouncementsTimeline component.
@@ -69,8 +70,11 @@ export const AnnouncementsTimeline = ({
     max: maxResults,
   });
 
-  if (loading || !announcements || announcements.count === 0)
-    return <>No announcements</>;
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (!announcements || announcements.count === 0) return <>No announcements</>;
 
   if (error) return <>Error: {error.message}</>;
 

--- a/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
+++ b/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
@@ -1,4 +1,4 @@
-import { useApi, useRouteRef } from '@backstage/core-plugin-api';
+import { useRouteRef } from '@backstage/core-plugin-api';
 import { Typography, Box } from '@material-ui/core';
 import {
   Timeline,
@@ -9,13 +9,12 @@ import {
   TimelineDot,
   TimelineSeparator,
 } from '@material-ui/lab';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import Stack from '@mui/material/Stack';
 import { DateTime } from 'luxon';
 import { announcementViewRouteRef } from '../../routes';
-import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
-import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
+import { useAnnouncements } from '@procore-oss/backstage-plugin-announcements-react';
 
 /**
  * Props for the AnnouncementsTimeline component.
@@ -64,23 +63,16 @@ export const AnnouncementsTimeline = ({
   timelineAlignment = DEFAULT_TIMELINE_ALIGNMENT,
   timelineMinWidth = DEFAULT_TIMELINE_WIDTH,
 }: AnnouncementsTimelineProps) => {
-  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
-  const announcementsApi = useApi(announcementsApiRef);
   const viewAnnouncementLink = useRouteRef(announcementViewRouteRef);
 
-  useEffect(() => {
-    async function fetchData() {
-      const { results } = await announcementsApi.announcements({
-        max: maxResults,
-      });
-      setAnnouncements(results);
-    }
+  const { announcements, loading, error } = useAnnouncements({
+    max: maxResults,
+  });
 
-    fetchData();
-  }, [announcementsApi, maxResults]);
-
-  if (!announcements || announcements.length === 0)
+  if (loading || !announcements || announcements.length === 0)
     return <>No announcements</>;
+
+  if (error) return <>Error: {error.message}</>;
 
   return (
     <Stack

--- a/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
+++ b/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
@@ -69,7 +69,7 @@ export const AnnouncementsTimeline = ({
     max: maxResults,
   });
 
-  if (loading || !announcements || announcements.length === 0)
+  if (loading || !announcements || announcements.count === 0)
     return <>No announcements</>;
 
   if (error) return <>Error: {error.message}</>;
@@ -83,7 +83,7 @@ export const AnnouncementsTimeline = ({
     >
       <Box sx={{ minWidth: timelineMinWidth }}>
         <Timeline align={timelineAlignment}>
-          {announcements.map(a => (
+          {announcements.results.map(a => (
             <TimelineItem key={`ti-${a.id}`}>
               <TimelineOppositeContent
                 key={`toc-${a.id}`}

--- a/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
+++ b/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useAsyncRetry } from 'react-use';
 import {
   Page,
   Header,
@@ -8,14 +7,10 @@ import {
   TableColumn,
   ErrorPanel,
 } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
 import { Button, makeStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import { NewCategoryDialog } from '../NewCategoryDialog';
-import {
-  announcementsApiRef,
-  useCategories,
-} from '@procore-oss/backstage-plugin-announcements-react';
+import { useCategories } from '@procore-oss/backstage-plugin-announcements-react';
 import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({

--- a/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
+++ b/plugins/announcements/src/components/CategoriesPage/CategoriesPage.tsx
@@ -12,7 +12,10 @@ import { useApi } from '@backstage/core-plugin-api';
 import { Button, makeStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import { NewCategoryDialog } from '../NewCategoryDialog';
-import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  announcementsApiRef,
+  useCategories,
+} from '@procore-oss/backstage-plugin-announcements-react';
 import { Category } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({
@@ -32,11 +35,7 @@ const CategoriesTable = () => {
   const classes = useStyles();
   const [newCategoryDialogOpen, setNewCategoryDialogOpen] = useState(false);
 
-  const announcementsApi = useApi(announcementsApiRef);
-  const { value, loading, error, retry } = useAsyncRetry(
-    () => announcementsApi.categories(),
-    [announcementsApi],
-  );
+  const { categories, loading, error, retry } = useCategories();
 
   if (error) {
     return <ErrorPanel error={error} />;
@@ -63,7 +62,7 @@ const CategoriesTable = () => {
     <>
       <Table
         options={{ paging: false }}
-        data={value || []}
+        data={categories || []}
         columns={columns}
         isLoading={loading}
         title="Categories"

--- a/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -12,7 +12,10 @@ import {
 import { Alert } from '@material-ui/lab';
 import Close from '@material-ui/icons/Close';
 import { announcementViewRouteRef } from '../../routes';
-import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
+import {
+  announcementsApiRef,
+  useAnnouncements,
+} from '@procore-oss/backstage-plugin-announcements-react';
 import { Announcement } from '@procore-oss/backstage-plugin-announcements-common';
 
 const useStyles = makeStyles(theme => ({
@@ -113,16 +116,11 @@ type NewAnnouncementBannerProps = {
 
 export const NewAnnouncementBanner = (props: NewAnnouncementBannerProps) => {
   const announcementsApi = useApi(announcementsApiRef);
-  const {
-    value: announcements,
-    loading,
-    error,
-  } = useAsync(async () =>
-    announcementsApi.announcements({
-      max: props.max || 1,
-      category: props.category,
-    }),
-  );
+
+  const { announcements, loading, error } = useAnnouncements({
+    max: props.max || 1,
+    category: props.category,
+  });
   const lastSeen = announcementsApi.lastSeenDate();
 
   if (loading) {
@@ -131,15 +129,13 @@ export const NewAnnouncementBanner = (props: NewAnnouncementBannerProps) => {
     return <Alert severity="error">{error.message}</Alert>;
   }
 
-  if (announcements?.count === 0) {
+  if (announcements.length === 0) {
     return null;
   }
 
-  const unseenAnnouncements = (announcements?.results || []).filter(
-    announcement => {
-      return lastSeen < DateTime.fromISO(announcement.created_at);
-    },
-  );
+  const unseenAnnouncements = (announcements || []).filter(announcement => {
+    return lastSeen < DateTime.fromISO(announcement.created_at);
+  });
 
   if (unseenAnnouncements?.length === 0) {
     return null;

--- a/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useAsync } from 'react-use';
 import { DateTime } from 'luxon';
 import { Link } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
@@ -129,11 +128,11 @@ export const NewAnnouncementBanner = (props: NewAnnouncementBannerProps) => {
     return <Alert severity="error">{error.message}</Alert>;
   }
 
-  if (announcements.length === 0) {
+  if (announcements.count === 0) {
     return null;
   }
 
-  const unseenAnnouncements = (announcements || []).filter(announcement => {
+  const unseenAnnouncements = announcements.results.filter(announcement => {
     return lastSeen < DateTime.fromISO(announcement.created_at);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,6 +5832,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
     luxon: ^3.4.4
+    react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   languageName: unknown


### PR DESCRIPTION
I continued to notice a need for having hooks when working on https://github.com/procore-oss/backstage-plugin-announcements/pull/326.

This PR adds two new hooks and reactors to the front end where applicable. While primarily used to refactor existing code, adopters could elect to use these hooks to retrieve and display announcements as they see fit. 

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
