### PR TITLE
chore: group dependabot updates when minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,23 @@ updates:
     open-pull-requests-limit: 15
     labels:
       - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: 'github-actions'
     directory: '/' # Must be set to "/" to check for workflow files in .github/workflows
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,54 +1,39 @@
 name: CI
 on: [pull_request]
-
 permissions:
   contents: read
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [18.x]
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         with:
           fetch-depth: '0'
-
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-
       - run: yarn install --immutable
-
       - run: yarn lint:all
-
       - run: yarn tsc
-
       - run: yarn build
-
   tests:
     name: Tests
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [18.x]
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-
       - run: yarn install --immutable
-
       - run: yarn test:all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,50 +2,38 @@ name: Release
 on:
   push:
     branches: [main]
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   release:
     name: Create Changeset PR
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: 18.x
           cache: 'yarn'
-
       - name: Install Dependencies
         run: yarn install --immutable
-
       - name: Build type declarations
         run: yarn tsc
-
       - name: Build packages
         run: yarn build
-
       - name: Enable non-immutable yarn installs
         run: yarn config set -H enableImmutableInstalls false
-
       - name: Authenticate yarn with NPM
         run: yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1
         with:
           version: yarn version
-          publish:
-            yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          publish: yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish git tags
         run: yarn changeset tag
         env:


### PR DESCRIPTION
- [x] change dependabot config to group dependencies
  - leave major dependency updates to their own PR so they stand out and are tested correctly
  - prefix the PRs with `chore(deps)` to adhere to conventional commits
- [x] change GitHub Actions to use SHAs instead of tags
  - Why?
    - To prevent supply chain attack. Tags can move. They are mutable. SHAs are not.
  - used [frizbee](https://github.com/stacklok/frizbee)
    - ran `frizbee ghactions -d .github/workflows` locally
    - also fixes formatting

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
