### PR TITLE
Bug Report: Announcement category cannot be deleted in certain scenarios

### DIFF
--- a/.changeset/late-bags-fly.md
+++ b/.changeset/late-bags-fly.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': minor
+---
+
+Bug Report: Announcement category cannot be deleted in certain scenarios

--- a/.changeset/red-hats-notice.md
+++ b/.changeset/red-hats-notice.md
@@ -1,0 +1,10 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': minor
+'@procore-oss/backstage-plugin-announcements-react': minor
+'@procore-oss/backstage-plugin-announcements': minor
+---
+
+Able to delete Announcement Categories for following benefits:-
+
+1. If created by mistake, a user can delete that
+2. Categories doesn't get cluttered

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -122,7 +122,10 @@ export class AnnouncementsDatabase {
     }
 
     return {
-      count: countResult && countResult.total ? countResult.total : 0,
+      count:
+        countResult && countResult.total
+          ? parseInt(countResult.total.toString(), 10)
+          : 0,
       results: (await queryBuilder.select()).map(DBToAnnouncementWithCategory),
     };
   }


### PR DESCRIPTION
Bug Report: Announcement category cannot be deleted in certain scenarios #385

Signed-off-by: elavsai lavanya.sainik@ericsson.com

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
