### PR TITLE
Add react-dom as peer dependency

### DIFF
--- a/.changeset/fluffy-geese-dream.md
+++ b/.changeset/fluffy-geese-dream.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements': minor
+---
+
+Add react-dom as a peer-dependency

--- a/plugins/announcements/package.json
+++ b/plugins/announcements/package.json
@@ -78,6 +78,7 @@
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6766,6 +6766,7 @@ __metadata:
     slugify: 1.6.6
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Checklist:

Announcements depends on @backstage/core-components, which itself has a [peerDependency](https://github.com/backstage/backstage/blob/master/packages/core-components/package.json#L122) on react-dom; so we need to either fulfill that dependency or declare it a peerDependency of our own!

* [ ] I have updated the necessary documentation
* [X] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
