### PR TITLE
docs(setup): Usage Error: The --cwd option is ambiguous

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,7 +7,7 @@
 Add the plugin to your backend app:
 
 ```bash
-yarn add --cwd packages/backend @procore-oss/backstage-plugin-announcements-backend
+yarn --cwd packages/backend add @procore-oss/backstage-plugin-announcements-backend
 ```
 
 Create `packages/backend/src/plugins/announcements.ts`:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -73,7 +73,7 @@ async function main() {
 Add the plugin to your backend app:
 
 ```bash
-yarn add --cwd packages/backend @procore-oss/backstage-plugin-announcements-backend
+yarn --cwd packages/backend add @procore-oss/backstage-plugin-announcements-backend
 ```
 
 Update `packages/backend/src/index.ts` to import announcements plugin package and register it in your backend using:
@@ -91,7 +91,7 @@ backend.add(import('@procore-oss/backstage-plugin-announcements-backend'));
 Add the plugin to your frontend app:
 
 ```bash
-yarn add --cwd packages/app @procore-oss/backstage-plugin-announcements
+yarn --cwd packages/app add @procore-oss/backstage-plugin-announcements
 ```
 
 Expose the announcements page:
@@ -118,7 +118,7 @@ An interface to create/update/edit/delete announcements is now available at `/an
 Add the plugin to your frontend app:
 
 ```bash
-yarn add --cwd packages/app @procore-oss/backstage-plugin-announcements
+yarn --cwd packages/app add @procore-oss/backstage-plugin-announcements
 ```
 
 Add the plugin to `packages/app/src/App.tsx`:


### PR DESCRIPTION
When following the setup instructions, the following error occurs:

```
Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path
```

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
