### PR TITLE
fix: yarn version script name collision

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1
         with:
-          version: yarn version
+          version: yarn version-packages
           publish: yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format:check": "prettier --check .",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
-    "version": "changeset version && yarn install && (git commit -am 'Update internal dependencies' || true)",
+    "version-packages": "changeset version && yarn install && (git commit -am 'Update internal dependencies' || true)",
     "release": "changeset publish",
     "knip": "knip",
     "prepare": "husky",


### PR DESCRIPTION
`yarn version` is a yarn4 command, and is now colliding with our package.json script name that generates the changset PR. 

This PR updates the name of the script to `version-packages` to prevent a collision.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
