### PR TITLE
ci: git push --follow-tags for github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,22 +11,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      
       - name: Use Node.js 20.x
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: 20.x
           cache: 'yarn'
+      
       - name: Install Dependencies
         run: yarn install --immutable
+      
       - name: Build type declarations
         run: yarn tsc
+      
       - name: Build packages
         run: yarn build:all
+      
       - name: Enable non-immutable yarn installs
         run: yarn config set -H enableImmutableInstalls false
+ 
       - name: Authenticate yarn with NPM
         run: yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+        
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1
         with:
           version: yarn version-packages
@@ -34,8 +42,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          
       - name: Publish git tags
-        run: yarn changeset tag
+        run: yarn changeset tag && git push --follow-tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Update the release workflow to include `git push --follow-tags`. This is required after running `yarn changeset tag` and will hopefully resolve why releases are not updating on Github. 

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
