### PR TITLE
fix: export announcements admin portal

### DIFF
--- a/.changeset/strong-balloons-visit.md
+++ b/.changeset/strong-balloons-visit.md
@@ -1,0 +1,21 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+fix: `AdminPortal` was not available for export.
+
+Taking the opportunity to update `AdminPortal` to `AnnouncementsAdminPortal` and make available for export
+
+```tsx
+  import { AnnouncementsAdminPortal } from '@procore-oss/backstage-plugin-announcements';
+
+  // default
+  <AnnouncementsAdminPortal />
+
+  // supports optional props
+  <AnnouncementsAdminPortal
+    title='my title'
+    subtitle='my subtitle'
+    themeId='my theme'
+  >
+```

--- a/plugins/announcements/src/plugin.ts
+++ b/plugins/announcements/src/plugin.ts
@@ -51,6 +51,14 @@ export const AnnouncementsPage = announcementsPlugin.provide(
   }),
 );
 
+export const AnnouncementsAdminPortal = announcementsPlugin.provide(
+  createRoutableExtension({
+    name: 'AnnouncementsAdminPortal',
+    component: () => import('./components/Admin').then(m => m.AdminPortal),
+    mountPoint: rootRouteRef,
+  }),
+);
+
 export const AnnouncementsTimeline = announcementsPlugin.provide(
   createComponentExtension({
     name: 'AnnouncementsTimeline',


### PR DESCRIPTION
### Summary 📰

The `<AnnouncementsAdminPortal />` should now be exported and available to use.

