### PR TITLE
fix: returning incorrect count of announcements when apply filters

### DIFF
--- a/.changeset/clever-rings-protect.md
+++ b/.changeset/clever-rings-protect.md
@@ -1,0 +1,22 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Fixes an issue with the announcements count returning the incorrect value when filters are applied.
+
+For example, if there are 2 total announcements in the database, and you request a `max` of 1 announcement, the count would still return 2.
+
+```ts
+// before
+{
+  count: 2,
+  announcements: [mostRecentAnnouncement]
+}
+
+
+// after
+{
+  count: 1,
+  announcements: [mostRecentAnnouncement]
+}
+```

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -259,7 +259,7 @@ describe('AnnouncementsDatabase', () => {
       });
 
       expect(announcements).toEqual({
-        count: 2,
+        count: 1,
         results: [
           {
             id: 'id',
@@ -293,19 +293,37 @@ describe('AnnouncementsDatabase', () => {
         created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
       });
 
+      await store.insertAnnouncement({
+        id: 'id3',
+        publisher: 'publisher3',
+        title: 'title3',
+        excerpt: 'excerpt3',
+        body: 'body3',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      await store.insertAnnouncement({
+        id: 'id4',
+        publisher: 'publisher4',
+        title: 'title4',
+        excerpt: 'excerpt4',
+        body: 'body4',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
       const announcements = await store.announcements({
         max: 1,
       });
 
       expect(announcements).toEqual({
-        count: 2,
+        count: 1,
         results: [
           {
-            id: 'id2',
-            publisher: 'publisher2',
-            title: 'title2',
-            excerpt: 'excerpt2',
-            body: 'body2',
+            id: 'id4',
+            publisher: 'publisher4',
+            title: 'title4',
+            excerpt: 'excerpt4',
+            body: 'body4',
             category: undefined,
             created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
           },

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -87,12 +87,14 @@ export class AnnouncementsDatabase {
   async announcements(
     request: AnnouncementsFilters,
   ): Promise<AnnouncementModelsList> {
+    const { category, offset, max } = request;
+
     const countQueryBuilder = this.db<DbAnnouncement>(announcementsTable).count<
       Record<string, number>
     >('id', { as: 'total' });
 
-    if (request.category) {
-      countQueryBuilder.where('category', request.category);
+    if (category) {
+      countQueryBuilder.where('category', category);
     }
 
     const countResult = await countQueryBuilder.first();
@@ -111,22 +113,37 @@ export class AnnouncementsDatabase {
       .orderBy('created_at', 'desc')
       .leftJoin('categories', 'announcements.category', 'categories.slug');
 
-    if (request.category) {
-      queryBuilder.where('category', request.category);
+    if (category) {
+      queryBuilder.where('category', category);
     }
-    if (request.offset) {
-      queryBuilder.offset(request.offset);
+    if (offset) {
+      queryBuilder.offset(offset);
     }
-    if (request.max) {
-      queryBuilder.limit(request.max);
+    if (max) {
+      queryBuilder.limit(max);
+    }
+
+    const results = (await queryBuilder.select()).map(
+      DBToAnnouncementWithCategory,
+    );
+
+    let count =
+      countResult && countResult.total
+        ? parseInt(countResult.total.toString(), 10)
+        : 0;
+
+    /*
+     * If we have a filter, we need to calculate the count
+     * based on the results we have, as the count query will not
+     * take into account the filter (i.e., limit and offset).
+     */
+    if (max || offset) {
+      count = results.length;
     }
 
     return {
-      count:
-        countResult && countResult.total
-          ? parseInt(countResult.total.toString(), 10)
-          : 0,
-      results: (await queryBuilder.select()).map(DBToAnnouncementWithCategory),
+      count,
+      results,
     };
   }
 


### PR DESCRIPTION
### Summary 📰

Fixes an issue where the count returned when applying a filter such as `max` is incorrect.

### Details 📚

The count is currently not taking into account the number of announcements being filtered out.

#### Checklist ✅

- [ ] I have updated the necessary documentation
- [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
- [x] My build is green

### Testing Notes 🔬

- [x] fixed the unit tests - there were incorrect
