### PR TITLE
Add the ability to optionally hide the context menu

### DIFF
--- a/.changeset/strange-pants-own.md
+++ b/.changeset/strange-pants-own.md
@@ -1,0 +1,7 @@
+---
+'@procore-oss/backstage-plugin-announcements': patch
+---
+
+Add the ability to hide the context menu via a `hideContextMenu` boolean property.
+
+The menu to access creating categories now includes a link to access the admin portal. However, the menu appears by default on the announcements page, and you may not want it visible to end users. Permissions are in place once a user lands on the admin portal, but it would be better to hide the menu altogether.

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -8,7 +8,7 @@ import { AnnouncementsPage } from './AnnouncementsPage';
 import { rootRouteRef } from '../../routes';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { announcementsApiRef } from '@procore-oss/backstage-plugin-announcements-react';
 
 const mockAnnouncements = [
@@ -36,7 +36,7 @@ describe('AnnouncementsPage', () => {
   };
 
   it('should render', async () => {
-    const rendered = await renderInTestApp(
+    await renderInTestApp(
       <TestApiProvider
         apis={[
           [permissionApiRef, mockPermissionApi],
@@ -53,12 +53,38 @@ describe('AnnouncementsPage', () => {
         },
       },
     );
-    expect(rendered.getByText('Announcements')).toBeInTheDocument();
+    expect(screen.getByText('Announcements')).toBeInTheDocument();
+  });
+
+  it('should hide context menu', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [permissionApiRef, mockPermissionApi],
+          [announcementsApiRef, mockAnnouncementsApi],
+          [catalogApiRef, mockCatalogApi],
+        ]}
+      >
+        <AnnouncementsPage
+          themeId="home"
+          title="Announcements"
+          hideContextMenu
+        />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/announcements': rootRouteRef,
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(screen.queryByTestId('announcements-context-menu')).toBeNull();
   });
 
   describe('AnnouncementCard', () => {
     it('should render announcement card title', async () => {
-      const rendered = await renderInTestApp(
+      await renderInTestApp(
         <TestApiProvider
           apis={[
             [permissionApiRef, mockPermissionApi],
@@ -75,13 +101,13 @@ describe('AnnouncementsPage', () => {
           },
         },
       );
-      expect(rendered.getByText('Announcements')).toBeInTheDocument();
-      expect(rendered.getByText('announcement-title')).toBeInTheDocument();
-      expect(rendered.getByText('excerpt')).toBeInTheDocument();
+      expect(screen.getByText('Announcements')).toBeInTheDocument();
+      expect(screen.getByText('announcement-title')).toBeInTheDocument();
+      expect(screen.getByText('excerpt')).toBeInTheDocument();
     });
 
     it('should render with overridden announcement card length', async () => {
-      const rendered = await renderInTestApp(
+      await renderInTestApp(
         <TestApiProvider
           apis={[
             [permissionApiRef, mockPermissionApi],
@@ -104,15 +130,13 @@ describe('AnnouncementsPage', () => {
         },
       );
 
-      expect(rendered.getByText('Announcements')).toBeInTheDocument();
-      expect(rendered.queryByText('announcement-title')).toBeNull();
-      expect(rendered.getByText('announcement-...')).toBeInTheDocument();
-      expect(rendered.getByText('New customNoun')).toBeInTheDocument();
+      expect(screen.getByText('Announcements')).toBeInTheDocument();
+      expect(screen.queryByText('announcement-title')).toBeNull();
+      expect(screen.getByText('announcement-...')).toBeInTheDocument();
+      expect(screen.getByText('New customNoun')).toBeInTheDocument();
 
-      fireEvent.mouseOver(rendered.getByText('announcement-...'));
-      expect(
-        await rendered.findByText('announcement-title'),
-      ).toBeInTheDocument();
+      fireEvent.mouseOver(screen.getByText('announcement-...'));
+      expect(await screen.findByText('announcement-title')).toBeInTheDocument();
     });
   });
 });

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -312,6 +312,7 @@ type AnnouncementsPageProps = {
   category?: string;
   buttonOptions?: AnnouncementCreateButtonProps;
   cardOptions?: AnnouncementCardProps;
+  hideContextMenu?: boolean;
 };
 
 export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
@@ -321,10 +322,12 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
   const { loading: loadingCreatePermission, allowed: canCreate } =
     usePermission({ permission: announcementCreatePermission });
 
+  const { hideContextMenu } = props;
+
   return (
     <Page themeId={props.themeId}>
       <Header title={props.title} subtitle={props.subtitle}>
-        <ContextMenu />
+        {!hideContextMenu && <ContextMenu />}
       </Header>
 
       <Content>

--- a/plugins/announcements/src/components/AnnouncementsPage/ContextMenu.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/ContextMenu.tsx
@@ -14,6 +14,7 @@ import {
   announcementAdminRouteRef,
   categoriesListRouteRef,
 } from '../../routes';
+import Box from '@mui/material/Box';
 
 const useStyles = makeStyles({
   button: {
@@ -37,7 +38,7 @@ export function ContextMenu() {
   };
 
   return (
-    <>
+    <Box data-testid="announcements-context-menu">
       <IconButton
         aria-label="more"
         aria-controls="long-menu"
@@ -72,6 +73,6 @@ export function ContextMenu() {
           </MenuItem>
         </MenuList>
       </Popover>
-    </>
+    </Box>
   );
 }

--- a/plugins/announcements/src/components/Router.tsx
+++ b/plugins/announcements/src/components/Router.tsx
@@ -24,6 +24,7 @@ type RouterProps = {
   title?: string;
   subtitle?: string;
   category?: string;
+  hideContextMenu?: boolean;
   cardOptions?: {
     titleLength: number | undefined;
   };


### PR DESCRIPTION
### Summary 📰

Users can now pass in `hideContextMenu` set to true to remove the context menu from the Announcements Page.

### Details 📚

**Visibile (default)**

![image](https://github.com/user-attachments/assets/76ae73b1-c841-419e-81c0-b811bffd7095)

**Hidden**

![image](https://github.com/user-attachments/assets/abc1bf47-942d-437e-8495-55913b034dc4)


#### Checklist ✅

- [ ] I have updated the necessary documentation
- [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
- [x] My build is green

### Testing Notes 🔬

- [X] unit tests updated
- [X] testing functionality locally
