### PR TITLE
Return the proper full count from DB queries

### DIFF
--- a/.changeset/flat-dancers-kneel.md
+++ b/.changeset/flat-dancers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@procore-oss/backstage-plugin-announcements-backend': patch
+---
+
+Fixed the returned 'count' on DB queries. This solves the issue with pagination not working.

--- a/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -265,7 +265,7 @@ describe('AnnouncementsDatabase', () => {
         title: 'title2',
         excerpt: 'excerpt2',
         body: 'body2',
-        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        created_at: DateTime.fromISO('2023-10-26T15:28:09.539Z'),
         active: true,
       });
 
@@ -274,7 +274,7 @@ describe('AnnouncementsDatabase', () => {
       });
 
       expect(announcements).toEqual({
-        count: 1,
+        count: 2,
         results: [
           {
             id: 'id',
@@ -336,7 +336,7 @@ describe('AnnouncementsDatabase', () => {
       });
 
       expect(announcements).toEqual({
-        count: 1,
+        count: 4,
         results: [
           {
             id: 'id4',


### PR DESCRIPTION
### Summary 📰

This fixes #495 and effectively reverts #464 which is incorrect.

The UI uses the `count` field to build the navigation between pages, to know how many pages exist, and allow traversing them. #464 broke this, by returning `count` as the number returned entries (an unnecessary value really - `.length` would suffice for that).

The PR also updates and fixes the tests to reflect this.

The DB logic was slightly refactored to be easier to understand, by having two filter functions (`filterState()` and `filterRange()`), both being used by the main result query, but only the first being used for the count query. This results in a proper `count` value.

The changeset for #464 says:

> For example, if there are 2 total announcements in the database, and you request a `max` of 1 announcement, the count would still return 2.

This was actually correct. If you only want 1 announcement, it makes perfect sense to return the total number of announcements (i.e. 2) as `count`. It's also necessary for pagination.

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

#### Checklist ✅

- [ ] I have updated the necessary documentation
- [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
- [x] My build is green

### Testing Notes 🔬

To reproduce; Have more announcements than shown in the main page (first page). The bottom page navigation doesn't work. It does with this PR.